### PR TITLE
fix(EmptyState): Empty state buttons handler IOS-7012

### DIFF
--- a/Mistica/Source/Components/EmptyState/EmptyState.swift
+++ b/Mistica/Source/Components/EmptyState/EmptyState.swift
@@ -73,15 +73,14 @@ public extension EmptyState {
         }
     }
 
-	var iconTintColor: UIColor {
-
-		get {
-			emptyStateContentBase.iconTintColor
-		}
-		set {
-			emptyStateContentBase.iconTintColor = newValue
-		}
-	}
+    var iconTintColor: UIColor {
+        get {
+            emptyStateContentBase.iconTintColor
+        }
+        set {
+            emptyStateContentBase.iconTintColor = newValue
+        }
+    }
 
     var primaryButton: Button {
         emptyStateContentBase.emptyStateButtons.primaryButton

--- a/Mistica/Source/Components/EmptyState/EmptyState.swift
+++ b/Mistica/Source/Components/EmptyState/EmptyState.swift
@@ -73,6 +73,16 @@ public extension EmptyState {
         }
     }
 
+	var iconTintColor: UIColor {
+
+		get {
+			emptyStateContentBase.iconTintColor
+		}
+		set {
+			emptyStateContentBase.iconTintColor = newValue
+		}
+	}
+
     var primaryButton: Button {
         emptyStateContentBase.emptyStateButtons.primaryButton
     }

--- a/Mistica/Source/Components/EmptyState/EmptyStateConfiguration.swift
+++ b/Mistica/Source/Components/EmptyState/EmptyStateConfiguration.swift
@@ -10,7 +10,7 @@ import Foundation
 import UIKit
 
 public struct EmptyStateConfiguration {
-    static let empty = EmptyStateConfiguration(type: .default(.icon(UIImage(color: .success))), title: "Basic configuration", description: "This is a basic configuration for the empty state", actions: nil)
+    static let empty = EmptyStateConfiguration(type: .default(.icon(UIImage())), title: "Basic configuration", description: "This is a basic configuration for the empty state", actions: nil)
 
     public enum EmptyStateActions {
         case primary(EmptyStateButton)
@@ -43,7 +43,7 @@ public struct EmptyStateConfiguration {
     let description: String?
     let actions: EmptyStateActions?
 
-    public init(type: EmptyStateType = .default(.icon(UIImage())), title: String, description: String?, actions: EmptyStateActions? = nil) {
+    public init(type: EmptyStateType, title: String, description: String?, actions: EmptyStateActions? = nil) {
         self.type = type
         self.title = title
         self.description = description

--- a/Mistica/Source/Components/EmptyState/Internals/EmptyStateButtons.swift
+++ b/Mistica/Source/Components/EmptyState/Internals/EmptyStateButtons.swift
@@ -45,9 +45,12 @@ class EmptyStateButtons: UIStackView {
 
 extension EmptyStateButtons {
     func configureButtons(primaryButton: EmptyStateButton? = nil, secondaryButton: EmptyStateButton? = nil, linkButton: EmptyStateLinkButton? = nil, isCard: Bool = false) {
-        configure(for: self.primaryButton, with: primaryButton, isCard: isCard, actionHandler: primaryActionHandler)
-        configure(for: self.secondaryButton, with: secondaryButton, isCard: isCard, actionHandler: secondaryActionHandler)
-        configure(for: self.linkButton, with: linkButton, isCard: isCard, actionHandler: linkActionHandler)
+        configure(for: self.primaryButton, with: primaryButton, isCard: isCard)
+        primaryActionHandler = primaryButton?.tapHandler
+        configure(for: self.secondaryButton, with: secondaryButton, isCard: isCard)
+        secondaryActionHandler = secondaryButton?.tapHandler
+        configure(for: self.linkButton, with: linkButton, isCard: isCard)
+        linkActionHandler = linkButton?.tapHandler
 
         if !arrangedSubviews.isEmpty {
             addArrangedSubview(dummyView)
@@ -76,7 +79,7 @@ private extension EmptyStateButtons {
         linkButton.style = .link
     }
 
-    func configure(for button: Button, with emptyButton: EmptyStateButton?, isCard: Bool = false, actionHandler: (() -> Void)?) {
+    func configure(for button: Button, with emptyButton: EmptyStateButton?, isCard: Bool = false) {
         if let configButton = emptyButton {
             button.title = configButton.title
             button.loadingTitle = configButton.loadingTitle
@@ -89,7 +92,7 @@ private extension EmptyStateButtons {
         }
     }
 
-    func configure(for link: Button, with emptyLinkButton: EmptyStateLinkButton?, isCard: Bool = false, actionHandler: (() -> Void)?) {
+    func configure(for link: Button, with emptyLinkButton: EmptyStateLinkButton?, isCard: Bool = false) {
         if let linkButton = emptyLinkButton {
             link.title = linkButton.title
             link.contentMode = .left

--- a/Mistica/Source/Components/EmptyState/Internals/EmptyStateContentBase.swift
+++ b/Mistica/Source/Components/EmptyState/Internals/EmptyStateContentBase.swift
@@ -81,15 +81,14 @@ extension EmptyStateContentBase {
         }
     }
 
-	var iconTintColor: UIColor {
-
-		get {
-			iconImage.tintColor
-		}
-		set {
-			iconImage.tintColor = newValue
-		}
-	}
+    var iconTintColor: UIColor {
+        get {
+            iconImage.tintColor
+        }
+        set {
+            iconImage.tintColor = newValue
+        }
+    }
 
     func configure(withConfiguration configuration: EmptyStateConfiguration) {
         configureMessagesContent(withConfiguration: configuration)

--- a/Mistica/Source/Components/EmptyState/Internals/EmptyStateContentBase.swift
+++ b/Mistica/Source/Components/EmptyState/Internals/EmptyStateContentBase.swift
@@ -81,6 +81,16 @@ extension EmptyStateContentBase {
         }
     }
 
+	var iconTintColor: UIColor {
+
+		get {
+			iconImage.tintColor
+		}
+		set {
+			iconImage.tintColor = newValue
+		}
+	}
+
     func configure(withConfiguration configuration: EmptyStateConfiguration) {
         configureMessagesContent(withConfiguration: configuration)
         // Asset is mandatory

--- a/Mistica/Tests/MisticaTests/UI/EmptyStatesTests.swift
+++ b/Mistica/Tests/MisticaTests/UI/EmptyStatesTests.swift
@@ -137,7 +137,7 @@ final class EmptyStatesTests: XCTestCase {
         MisticaConfig.brandStyle = .movistar
 
         let view = makeEmptyStateWithContentAndButtons(type: .card(.icon(AnyValues.iconImage)), actions: .empty)
-		
+
         assertSnapshot(matching: view, as: .image)
     }
 

--- a/Mistica/Tests/MisticaTests/UI/EmptyStatesTests.swift
+++ b/Mistica/Tests/MisticaTests/UI/EmptyStatesTests.swift
@@ -120,7 +120,7 @@ final class EmptyStatesTests: XCTestCase {
     func testSecondaryAndLinkButtonsOnlyAsACard() {
         MisticaConfig.brandStyle = .movistar
 
-        let view = makeEmptyStateWithContentAndButtons(type: .card(.icon(AnyValues.smallImage)), actions: .secondaryAndLink(secondary: AnyValues.secondary, link: AnyValues.link))
+        let view = makeEmptyStateWithContentAndButtons(type: .card(.icon(AnyValues.iconImage)), actions: .secondaryAndLink(secondary: AnyValues.secondary, link: AnyValues.link))
 
         assertSnapshot(matching: view, as: .image)
     }
@@ -136,15 +136,15 @@ final class EmptyStatesTests: XCTestCase {
     func testEmptyButtonOnlyAsACard() {
         MisticaConfig.brandStyle = .movistar
 
-        let view = makeEmptyStateWithContentAndButtons(type: .card(.icon(AnyValues.smallImage)), actions: .empty)
-
+        let view = makeEmptyStateWithContentAndButtons(type: .card(.icon(AnyValues.iconImage)), actions: .empty)
+		
         assertSnapshot(matching: view, as: .image)
     }
 
     func testLinkButtonOnlyAsACard() {
         MisticaConfig.brandStyle = .movistar
 
-        let view = makeEmptyStateWithContentAndButtons(type: .card(.icon(AnyValues.smallImage)), actions: .link(AnyValues.link))
+        let view = makeEmptyStateWithContentAndButtons(type: .card(.icon(AnyValues.iconImage)), actions: .link(AnyValues.link))
 
         assertSnapshot(matching: view, as: .image)
     }

--- a/MisticaCatalog/Source/ComponentsCatalogs/UICatalogEmptyStateViewController.swift
+++ b/MisticaCatalog/Source/ComponentsCatalogs/UICatalogEmptyStateViewController.swift
@@ -232,7 +232,7 @@ extension UICatalogEmptyStateViewController: UITableViewDataSource, UITableViewD
             let asset = EmptyStateConfiguration.EmptyStateCardAsset.icon(image)
             configuration = EmptyStateConfiguration(type: .card(asset), title: emptyStateTitle, description: emptyStateMessage, actions: actions)
         } else {
-            let imageDefault = UIImage(color: .success)
+			let imageDefault = UIImage(color: .success)
             let asset: EmptyStateConfiguration.EmptyStateDefaultAsset
             switch assetCell.segmentedControl.selectedSegmentIndex {
             case 0:
@@ -249,6 +249,7 @@ extension UICatalogEmptyStateViewController: UITableViewDataSource, UITableViewD
         }
         let vc = EmptyStateViewSampleViewController()
         vc.emptyState.contentConfiguration = configuration
+		vc.emptyState.iconTintColor = .systemPink
 
         show(vc, sender: self)
     }

--- a/MisticaCatalog/Source/ComponentsCatalogs/UICatalogEmptyStateViewController.swift
+++ b/MisticaCatalog/Source/ComponentsCatalogs/UICatalogEmptyStateViewController.swift
@@ -199,23 +199,26 @@ extension UICatalogEmptyStateViewController: UITableViewDataSource, UITableViewD
         view.endEditing(true)
 
         let actions: EmptyStateConfiguration.EmptyStateActions
+        let handler: () -> Void = {
+            CroutonController.shared.showCrouton(withText: "The user has tapped any button")
+        }
         switch buttonsCell.segmentedControl.selectedSegmentIndex {
         case 0:
-            actions = .primary(EmptyStateButton(title: "Button small", loadingTitle: nil, tapHandler: nil))
+            actions = .primary(EmptyStateButton(title: "Button small", loadingTitle: nil, tapHandler: handler))
         case 1:
             actions = .primaryAndLink(
-                primary: EmptyStateButton(title: "Button small", loadingTitle: nil, tapHandler: nil),
-                link: EmptyStateLinkButton(title: "Link", tapHandler: nil)
+                primary: EmptyStateButton(title: "Button small", loadingTitle: nil, tapHandler: handler),
+                link: EmptyStateLinkButton(title: "Link", tapHandler: handler)
             )
         case 2:
-            actions = .secondary(EmptyStateButton(title: "Secondary", loadingTitle: nil, tapHandler: nil))
+            actions = .secondary(EmptyStateButton(title: "Secondary", loadingTitle: nil, tapHandler: handler))
         case 3:
             actions = .secondaryAndLink(
-                secondary: EmptyStateButton(title: "Secondary", loadingTitle: nil, tapHandler: nil),
-                link: EmptyStateLinkButton(title: "Link", tapHandler: nil)
+                secondary: EmptyStateButton(title: "Secondary", loadingTitle: nil, tapHandler: handler),
+                link: EmptyStateLinkButton(title: "Link", tapHandler: handler)
             )
         case 4:
-            actions = .link(EmptyStateLinkButton(title: "Link", tapHandler: nil))
+            actions = .link(EmptyStateLinkButton(title: "Link", tapHandler: handler))
         case 5:
             actions = .empty
         default:

--- a/MisticaCatalog/Source/ComponentsCatalogs/UICatalogEmptyStateViewController.swift
+++ b/MisticaCatalog/Source/ComponentsCatalogs/UICatalogEmptyStateViewController.swift
@@ -232,7 +232,7 @@ extension UICatalogEmptyStateViewController: UITableViewDataSource, UITableViewD
             let asset = EmptyStateConfiguration.EmptyStateCardAsset.icon(image)
             configuration = EmptyStateConfiguration(type: .card(asset), title: emptyStateTitle, description: emptyStateMessage, actions: actions)
         } else {
-			let imageDefault = UIImage(color: .success)
+            let imageDefault = UIImage(color: .success)
             let asset: EmptyStateConfiguration.EmptyStateDefaultAsset
             switch assetCell.segmentedControl.selectedSegmentIndex {
             case 0:
@@ -249,7 +249,7 @@ extension UICatalogEmptyStateViewController: UITableViewDataSource, UITableViewD
         }
         let vc = EmptyStateViewSampleViewController()
         vc.emptyState.contentConfiguration = configuration
-		vc.emptyState.iconTintColor = .systemPink
+        vc.emptyState.iconTintColor = .systemPink
 
         show(vc, sender: self)
     }


### PR DESCRIPTION
## *🎟️ Jira ticket*

[IOS-7012](https://jira.tid.es/browse/IOS-7012) Empty state buttons handler not working

## *🥅 What's the goal?*

Assign the handler defined by the developer to the desired buttons of the component

## *🚧 How do we do it*

We did it by assigning the handler defined outside of the component to the component vars defined for that

## *🧪 How can I test this?*

Downloading the catalog and inside the Empty state component tap any button.
https://install.appcenter.ms/orgs/tuenti-organization/apps/mistica-ios/distribution_groups/public

## *🏑  AppCenter build*

[Last version](https://install.appcenter.ms/orgs/tuenti-organization/apps/mistica-ios/distribution_groups/public)

## **📱 Demo**

https://user-images.githubusercontent.com/43632903/133466065-9f58fda4-808e-408e-bfea-783f5b146a9e.mov

