### PR TITLE
IOS-7156 ADD: Error Reference language token

### DIFF
--- a/Mistica/Source/Components/Feedback/FeedbackView.swift
+++ b/Mistica/Source/Components/Feedback/FeedbackView.swift
@@ -135,7 +135,7 @@ public class FeedbackView: UIView {
 
     private lazy var contentContainerStackView: UIStackView = {
         let stackView = UIStackView(arrangedSubviews: [titleLabel, subtitleLabel])
-        if !errorReference.isEmpty {
+		if !errorReference.isEmpty && style == .error {
             stackView.addArrangedSubview(errorReferenceLabel)
         }
         if let extraContent = extraContent {


### PR DESCRIPTION
## *🎟️ Jira ticket*

[IOS-7156](https://jira.tid.es/browse/IOS-7156) Error Reference in just Error Feedback Screen

## *🥅 What's the goal?*

aovad show the error reference in the styles that are not Error [Figma](https://www.figma.com/file/LpjgnU1xpmEzQvlXKwAHmn/Feedbacks-Screen-Specs?node-id=0%3A910)

## *🚧 How do we do it*

Edited Feedback component to avoid show the label

## *🧪 How can I test this?*

Downloading the catalog and see the new component inside the Empty state section.
https://install.appcenter.ms/orgs/tuenti-organization/apps/mistica-ios/distribution_groups/public

## *🏑  AppCenter build*

[Last version](https://install.appcenter.ms/orgs/tuenti-organization/apps/mistica-ios/distribution_groups/public)

## **📱 Demo**

https://user-images.githubusercontent.com/43632903/143010945-008f3528-7979-4725-9351-e563b66d68a7.mov

