### PR TITLE
fix(EmptyState): Missing accesiblity IDS in Empty state. Fix wrong color on InputField borders - SMARTWIFI-3416

### DIFF
--- a/Mistica/Source/Components/EmptyState/EmptyState.swift
+++ b/Mistica/Source/Components/EmptyState/EmptyState.swift
@@ -28,18 +28,6 @@ public class EmptyState: UIView {
         }
     }
 
-    override public var accessibilityElements: [Any]? {
-        get {
-            // We must set the frame and be sure it is already calculated.
-            emptyStateAccessibilityElement.accessibilityFrameInContainerSpace = bounds
-            return [
-                emptyStateAccessibilityElement,
-                emptyStateContentBase
-            ].compactMap { $0 }
-        }
-        set {}
-    }
-
     override public init(frame: CGRect) {
         super.init(frame: frame)
         commomInit()

--- a/Mistica/Source/Components/EmptyState/Internals/EmptyStateContentBase.swift
+++ b/Mistica/Source/Components/EmptyState/Internals/EmptyStateContentBase.swift
@@ -63,15 +63,6 @@ extension EmptyStateContentBase {
         }
     }
 
-    override var accessibilityElements: [Any]? {
-        get {
-            [
-                emptyStateButtons
-            ].compactMap { $0 }
-        }
-        set {}
-    }
-
     var iconContentMode: UIView.ContentMode {
         get {
             iconImage.contentMode
@@ -113,6 +104,7 @@ extension EmptyStateContentBase {
             iconImage.accessibilityIdentifier
         }
         set {
+            iconImage.isAccessibilityElement = true
             iconImage.accessibilityIdentifier = newValue
         }
     }

--- a/Mistica/Source/Components/InputField/InputField.swift
+++ b/Mistica/Source/Components/InputField/InputField.swift
@@ -291,16 +291,6 @@ public class InputField: UIView {
         }
     }
 
-    @objc public var borderColor: CGColor? {
-        get { borderedView.layer.borderColor }
-        set { borderedView.layer.borderColor = newValue }
-    }
-
-    @objc public var borderWidth: CGFloat {
-        get { borderedView.layer.borderWidth }
-        set { borderedView.layer.borderWidth = newValue }
-    }
-
     @objc public var returnKeyType: UIReturnKeyType {
         get { textInputView?.returnKeyType ?? .default }
         set { textInputView?.returnKeyType = newValue }
@@ -395,7 +385,7 @@ public class InputField: UIView {
     override public func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         guard traitCollection.userInterfaceStyle != previousTraitCollection?.userInterfaceStyle else { return }
-        borderColor = UIColor.divider.cgColor
+        borderColor = UIColor.border.cgColor
     }
 }
 


### PR DESCRIPTION
Appium, wasn't able to see elements in the EmptyState as the accesibility elements were being overriden with the `accessibilityElements` array. With these fixes now Appium can detect all elements inside the EmptyState, and voiceover still reads the text as a single element (it doesn't jump from one label to the next)

![image](https://user-images.githubusercontent.com/2429905/151158400-4b3983fe-bcb6-4335-9006-e79c8701a4ed.png)

- Bonus fix: `InputField.swift` was using the incorrect color for the border

This code has already been used to generate a "maintenance" mistica version https://github.com/Telefonica/mistica-ios/releases/tag/v14.2.1, this PR is to add the fix also in `main`