### PR TITLE
fix(RadioButton): Accesibility traits

### DIFF
--- a/Mistica/Source/Components/RadioButton/RadioButton.swift
+++ b/Mistica/Source/Components/RadioButton/RadioButton.swift
@@ -55,10 +55,10 @@ public class RadioButton: UIControl {
 
     override public var accessibilityTraits: UIAccessibilityTraits {
         get {
-            if super.accessibilityTraits != customAccessiblityTraits {
-                return super.accessibilityTraits
+            if isActivated {
+                return super.accessibilityTraits.union([.button, .selected])
             } else {
-                return customAccessiblityTraits
+                return super.accessibilityTraits.union([.button])
             }
         }
         set {
@@ -94,14 +94,6 @@ public class RadioButton: UIControl {
 }
 
 private extension RadioButton {
-    var customAccessiblityTraits: UIAccessibilityTraits {
-        if isActivated {
-            return [.button, .selected]
-        } else {
-            return [.button]
-        }
-    }
-
     func commonInit() {
         updateViewStyle(activated: isActivated)
 


### PR DESCRIPTION
Radio button accessibility traits were not being correctly set, so when the radio button was selected there was no indication or way to tell from an accessibility inspector (like Appium)

Before, the element was being detected as `XCUIElementTypeOther`:

![image](https://user-images.githubusercontent.com/2429905/156374592-af76ca65-e5e3-49d4-a386-35f7f07cb1a5.png)

Now, the element is detected as `XCUIElementTypeButton`, with `value=1` when selected:

![MicrosoftTeams-image (4)](https://user-images.githubusercontent.com/2429905/156374776-e6501c5c-d010-4daa-88b8-6b0a7e51f6ba.png)

