### PR TITLE
fix(Assets): IOS-7644 Exclude common assets from  protocol

### DIFF
--- a/Sources/MisticaCommon/Assets/AssetToolkit+Image.swift
+++ b/Sources/MisticaCommon/Assets/AssetToolkit+Image.swift
@@ -12,31 +12,31 @@ import SwiftUI
 @available(iOS 13.0, *)
 public extension Image {
     static var arrowRight: Image {
-        Image(uiImage: MisticaConfig.currentBrandAssets.arrowRight)
+        Image(uiImage: .arrowRight)
     }
 
     static var checkmarkIcon: Image {
-        Image(uiImage: MisticaConfig.currentBrandAssets.checkmarkIcon)
+        Image(uiImage: .checkmarkIcon)
     }
 
     static var eyeEnabled: Image {
-        Image(uiImage: MisticaConfig.currentBrandAssets.eyeEnabled)
+        Image(uiImage: .eyeEnabled)
     }
 
     static var eyeDisabled: Image {
-        Image(uiImage: MisticaConfig.currentBrandAssets.eyeDisabled)
+        Image(uiImage: .eyeDisabled)
     }
 
     static var arrowDown: Image {
-        Image(uiImage: MisticaConfig.currentBrandAssets.arrowDown)
+        Image(uiImage: .arrowDown)
     }
 
     static var search: Image {
-        Image(uiImage: MisticaConfig.currentBrandAssets.search)
+        Image(uiImage: .search)
     }
 
     static var calendar: Image {
-        Image(uiImage: MisticaConfig.currentBrandAssets.calendar)
+        Image(uiImage: .calendar)
     }
 
     static var iconNotificationInfo: Image? {
@@ -44,6 +44,6 @@ public extension Image {
     }
 
     static var closeButtonBlackSmallIcon: Image {
-        Image(uiImage: MisticaConfig.currentBrandAssets.closeButtonBlackSmallIcon)
+        Image(uiImage: .closeButtonBlackSmallIcon)
     }
 }

--- a/Sources/MisticaCommon/Assets/AssetToolkit+UIImage.swift
+++ b/Sources/MisticaCommon/Assets/AssetToolkit+UIImage.swift
@@ -11,31 +11,31 @@ import UIKit
 
 public extension UIImage {
     static var arrowRight: UIImage {
-        MisticaConfig.currentBrandAssets.arrowRight
+        UIImage(named: "icn_arrow_right", type: .common)!
     }
 
     static var checkmarkIcon: UIImage {
-        MisticaConfig.currentBrandAssets.checkmarkIcon
+        UIImage(named: "icn_checkbox_check", type: .common)!
     }
 
     static var eyeEnabled: UIImage {
-        MisticaConfig.currentBrandAssets.eyeEnabled
+        UIImage(named: "icn_eye_enabled", type: .common)!
     }
 
     static var eyeDisabled: UIImage {
-        MisticaConfig.currentBrandAssets.eyeDisabled
+        UIImage(named: "icn_eye_disabled", type: .common)!
     }
 
     static var arrowDown: UIImage {
-        MisticaConfig.currentBrandAssets.arrowDown
+        UIImage(named: "icn_dropmenu", type: .common)!
     }
 
     static var search: UIImage {
-        MisticaConfig.currentBrandAssets.search
+        UIImage(named: "icn_search", type: .common)!
     }
 
     static var calendar: UIImage {
-        MisticaConfig.currentBrandAssets.calendar
+        UIImage(named: "icn_calendar", type: .common)!
     }
 
     static var iconNotificationInfo: UIImage? {
@@ -43,6 +43,6 @@ public extension UIImage {
     }
 
     static var closeButtonBlackSmallIcon: UIImage {
-        MisticaConfig.currentBrandAssets.closeButtonBlackSmallIcon
+        UIImage(named: "icn_close_black_small", type: .common)!
     }
 }

--- a/Sources/MisticaCommon/Assets/DefaultMisticaBrandAssets.swift
+++ b/Sources/MisticaCommon/Assets/DefaultMisticaBrandAssets.swift
@@ -14,40 +14,8 @@ public struct DefaultMisticaBrandAssets: MisticaBrandAssets {
         // Do nothing
     }
 
-    public var arrowRight: UIImage {
-        UIImage(named: "icn_arrow_right", type: .common)!
-    }
-
-    public var checkmarkIcon: UIImage {
-        UIImage(named: "icn_checkbox_check", type: .common)!
-    }
-
-    public var eyeEnabled: UIImage {
-        UIImage(named: "icn_eye_enabled", type: .common)!
-    }
-
-    public var eyeDisabled: UIImage {
-        UIImage(named: "icn_eye_disabled", type: .common)!
-    }
-
-    public var arrowDown: UIImage {
-        UIImage(named: "icn_dropmenu", type: .common)!
-    }
-
-    public var search: UIImage {
-        UIImage(named: "icn_search", type: .common)!
-    }
-
-    public var calendar: UIImage {
-        UIImage(named: "icn_calendar", type: .common)!
-    }
-
     public var iconNotificationInfo: UIImage? {
         UIImage(named: "icnNotificationInfo", type: .branded)!.withRenderingMode(.alwaysTemplate)
-    }
-
-    public var closeButtonBlackSmallIcon: UIImage {
-        UIImage(named: "icn_close_black_small", type: .common)!
     }
 
     public var checkAnimation: NSDataAsset? {

--- a/Sources/MisticaCommon/Assets/MisticaBrandAssets.swift
+++ b/Sources/MisticaCommon/Assets/MisticaBrandAssets.swift
@@ -10,16 +10,6 @@ import Foundation
 import SwiftUI
 
 public protocol MisticaBrandAssets {
-    var eyeEnabled: UIImage { get }
-    var eyeDisabled: UIImage { get }
-    var arrowDown: UIImage { get }
-    var search: UIImage { get }
-    var calendar: UIImage { get }
-
-    var arrowRight: UIImage { get }
-    var closeButtonBlackSmallIcon: UIImage { get }
-
-    var checkmarkIcon: UIImage { get }
     var iconNotificationInfo: UIImage? { get }
     var successAnimation: NSDataAsset? { get }
     var checkAnimation: NSDataAsset? { get }


### PR DESCRIPTION
https://jira.tid.es/browse/IOS-7644

I want to use this dependency (instead of mistica-ios-swiftui) in Zeus project. I've noticed that `MisticaBrandAssets` protocol includes some **common assets** plus the _branded_ ones. This protocol allows to customize the _branded_ assets when we use a custom brand instead of the existent ones (movistar, etc) so having to implement common resources every time we create a custom brand does not make sense.

What did I do??? I've just removed the common assets since they will be shared internally for all our brands included the custom ones.

I've not considered this a breaking change since the old clients will just to update and remove (if they want; the should) the excluded properties in the protocol.