### PR TITLE
IOS-7705 Allow icons from url in Sheet

### DIFF
--- a/MisticaCatalog/Source/Catalog/Mistica/Components/UICatalogSheetViewController.swift
+++ b/MisticaCatalog/Source/Catalog/Mistica/Components/UICatalogSheetViewController.swift
@@ -147,7 +147,7 @@ extension UICatalogSheetViewController: UITableViewDataSource, UITableViewDelega
                 id: index.description,
                 title: "Element \(index)",
                 description: "Description",
-                icon: assetCell.segmentedControl.selectedSegmentIndex == 0 ? .imageIcon : nil
+                icon: assetCell.segmentedControl.selectedSegmentIndex == 0 ? SheetListRowIcon(url: "https://img.icons8.com/ios-glyphs/344/bookmark.png", urlDark: "https://img.icons8.com/ios/344/bookmark--v1.png"): nil
             )
             rows.append(item)
         }

--- a/MisticaCatalog/Source/Catalog/Mistica/Components/UICatalogSheetViewController.swift
+++ b/MisticaCatalog/Source/Catalog/Mistica/Components/UICatalogSheetViewController.swift
@@ -147,7 +147,7 @@ extension UICatalogSheetViewController: UITableViewDataSource, UITableViewDelega
                 id: index.description,
                 title: "Element \(index)",
                 description: "Description",
-                icon: assetCell.segmentedControl.selectedSegmentIndex == 0 ? SheetListRowIcon(url: "https://img.icons8.com/ios-glyphs/344/bookmark.png", urlDark: "https://img.icons8.com/ios/344/bookmark--v1.png"): nil
+                icon: assetCell.segmentedControl.selectedSegmentIndex == 0 ? SheetListRowIcon(url: "https://img.icons8.com/ios-glyphs/344/bookmark.png", urlDark: "https://img.icons8.com/ios/344/bookmark--v1.png") : nil
             )
             rows.append(item)
         }

--- a/Sources/Mistica/Components/Sheet/Model/SheetConfiguration.swift
+++ b/Sources/Mistica/Components/Sheet/Model/SheetConfiguration.swift
@@ -78,19 +78,19 @@ public struct SheetListRow {
 }
 
 public struct SheetListRowIcon {
-	let url: String
-	let urlDark: String?
-	var urlToDisplay: String? {
-		if #available(iOS 13.0, *) {
-			return UITraitCollection.current.userInterfaceStyle == .light ? url : urlDark
-		} else {
-			return url
-		}
-	}
+    let url: String
+    let urlDark: String?
+    var urlToDisplay: String? {
+        if #available(iOS 13.0, *) {
+            return UITraitCollection.current.userInterfaceStyle == .light ? url : urlDark
+        } else {
+            return url
+        }
+    }
 
-	public init(url: String,
-				urlDark: String? = nil) {
-		self.url = url
-		self.urlDark = urlDark
-	}
+    public init(url: String,
+                urlDark: String? = nil) {
+        self.url = url
+        self.urlDark = urlDark
+    }
 }

--- a/Sources/Mistica/Components/Sheet/Model/SheetConfiguration.swift
+++ b/Sources/Mistica/Components/Sheet/Model/SheetConfiguration.swift
@@ -61,13 +61,13 @@ public struct SheetListRow {
     let id: String
     let title: String?
     let description: String?
-    let icon: UIImage?
+    let icon: SheetListRowIcon?
     let isSelected: Bool
 
     public init(id: String,
                 title: String? = nil,
                 description: String? = nil,
-                icon: UIImage? = nil,
+                icon: SheetListRowIcon? = nil,
                 isSelected: Bool = false) {
         self.id = id
         self.title = title
@@ -75,4 +75,22 @@ public struct SheetListRow {
         self.icon = icon
         self.isSelected = isSelected
     }
+}
+
+public struct SheetListRowIcon {
+	let url: String
+	let urlDark: String?
+	var urlToDisplay: String? {
+		if #available(iOS 13.0, *) {
+			return UITraitCollection.current.userInterfaceStyle == .light ? url : urlDark
+		} else {
+			return url
+		}
+	}
+
+	public init(url: String,
+				urlDark: String? = nil) {
+		self.url = url
+		self.urlDark = urlDark
+	}
 }

--- a/Sources/Mistica/Components/Sheet/Model/SheetConfiguration.swift
+++ b/Sources/Mistica/Components/Sheet/Model/SheetConfiguration.swift
@@ -80,13 +80,6 @@ public struct SheetListRow {
 public struct SheetListRowIcon {
     let url: String
     let urlDark: String?
-    var urlToDisplay: String? {
-        if #available(iOS 13.0, *) {
-            return UITraitCollection.current.userInterfaceStyle == .light ? url : urlDark
-        } else {
-            return url
-        }
-    }
 
     public init(url: String,
                 urlDark: String? = nil) {

--- a/Sources/Mistica/Components/Sheet/View/SheetView.swift
+++ b/Sources/Mistica/Components/Sheet/View/SheetView.swift
@@ -135,12 +135,17 @@ private extension SheetView {
                     imageView.heightAnchor.constraint(equalToConstant: 24.0).isActive = true
                     imageView.widthAnchor.constraint(equalToConstant: 24.0).isActive = true
                     imageView.contentMode = .scaleAspectFit
-                    if let urlToDisplay = icon.urlToDisplay,
-                       let url = URL(string: urlToDisplay),
-                       let data = try? Data(contentsOf: url) {
-                        imageView.image = UIImage(data: data)
-                    }
-
+					if let url = URL(string: icon.url),
+						let data = try? Data(contentsOf: url) {
+						let lightImage = UIImage(data: data)
+						if let iconDark = icon.urlDark,
+						   let urlDark = URL(string: iconDark),
+						   let dataDark = try? Data(contentsOf: urlDark),
+						   let darkImage = UIImage(data: dataDark) {
+								lightImage?.imageAsset?.register(darkImage, with: .init(userInterfaceStyle: .dark))
+						}
+						imageView.image = lightImage
+					}
                     itemStackView.addArrangedSubview(imageView)
                 }
 

--- a/Sources/Mistica/Components/Sheet/View/SheetView.swift
+++ b/Sources/Mistica/Components/Sheet/View/SheetView.swift
@@ -135,7 +135,12 @@ private extension SheetView {
                     imageView.heightAnchor.constraint(equalToConstant: 24.0).isActive = true
                     imageView.widthAnchor.constraint(equalToConstant: 24.0).isActive = true
                     imageView.contentMode = .scaleAspectFit
-                    imageView.image = icon
+					if let urlToDisplay = icon.urlToDisplay,
+					   let url = URL(string: urlToDisplay),
+					   let data = try? Data(contentsOf: url) {
+							imageView.image = UIImage(data: data)
+					}
+
                     itemStackView.addArrangedSubview(imageView)
                 }
 

--- a/Sources/Mistica/Components/Sheet/View/SheetView.swift
+++ b/Sources/Mistica/Components/Sheet/View/SheetView.swift
@@ -135,11 +135,11 @@ private extension SheetView {
                     imageView.heightAnchor.constraint(equalToConstant: 24.0).isActive = true
                     imageView.widthAnchor.constraint(equalToConstant: 24.0).isActive = true
                     imageView.contentMode = .scaleAspectFit
-					if let urlToDisplay = icon.urlToDisplay,
-					   let url = URL(string: urlToDisplay),
-					   let data = try? Data(contentsOf: url) {
-							imageView.image = UIImage(data: data)
-					}
+                    if let urlToDisplay = icon.urlToDisplay,
+                       let url = URL(string: urlToDisplay),
+                       let data = try? Data(contentsOf: url) {
+                        imageView.image = UIImage(data: data)
+                    }
 
                     itemStackView.addArrangedSubview(imageView)
                 }


### PR DESCRIPTION
Hi there!

This PR is a hotfix to map the icon parameter of the rows in the Sheet component. Until now it was thought that it was not going to be necessary to include it but we already have the definition and it is required for 13.8.

This parameter will come with two icon urls, one for the light mode and one for the dark mode. 