### PR TITLE
IOS-7708 Fix loop in accessibilityIdentifier

### DIFF
--- a/MisticaCatalog/Source/Catalog/MisticaSwiftUI/Components/DataCardCatalogView.swift
+++ b/MisticaCatalog/Source/Catalog/MisticaSwiftUI/Components/DataCardCatalogView.swift
@@ -38,6 +38,9 @@ struct DataCardCatalogView: View {
                 } linkButton: {
                     Button("Link") {}
                 }
+                .titleAccessibilityLabel("Title")
+                .subtitleAccessibilityIdentifier("Subtitle")
+                .accessibilityIdentifier("Identifier")
                 .padding(.horizontal, 16)
                 .navigationBarTitle("DataCard")
                 .navigationBarTitleDisplayMode(.inline)

--- a/MisticaCatalog/Source/Catalog/MisticaSwiftUI/Components/FeedbackCatalogView.swift
+++ b/MisticaCatalog/Source/Catalog/MisticaSwiftUI/Components/FeedbackCatalogView.swift
@@ -40,6 +40,8 @@ struct FeedbackCatalogView: View {
                 primaryButton: { Button("Primary", action: {}) },
                 secondaryButton: { Button("Secondary", action: {}) }
             )
+            .titleAccessibilityLabel("Title")
+            .imageAccessibilityIdentifier("Image")
         }
     }
 

--- a/Sources/MisticaSwiftUI/Utils/Backport.swift
+++ b/Sources/MisticaSwiftUI/Utils/Backport.swift
@@ -30,6 +30,16 @@ extension MisticaBackport where Content: View {
         }
     }
 
+    @ViewBuilder func accessibilityIdentifier(_ text: String) -> some View {
+        if #available(iOS 14.0, *) {
+            content
+                .accessibilityIdentifier(text)
+        } else {
+            content
+                .accessibility(identifier: text)
+        }
+    }
+    
     @ViewBuilder func accessibilityLabel(_ text: Text) -> some View {
         if #available(iOS 14.0, *) {
             content

--- a/Sources/MisticaSwiftUI/Utils/Backport.swift
+++ b/Sources/MisticaSwiftUI/Utils/Backport.swift
@@ -39,7 +39,7 @@ extension MisticaBackport where Content: View {
                 .accessibility(identifier: text)
         }
     }
-    
+
     @ViewBuilder func accessibilityLabel(_ text: Text) -> some View {
         if #available(iOS 14.0, *) {
             content

--- a/Sources/MisticaSwiftUI/Utils/Modifiers/AccessibilityViewModifier.swift
+++ b/Sources/MisticaSwiftUI/Utils/Modifiers/AccessibilityViewModifier.swift
@@ -26,7 +26,7 @@ struct OptionalAccessibilityIdentifier: ViewModifier {
 
     func body(content: Content) -> some View {
         if let identifier = identifier {
-            content.accessibilityIdentifier(identifier)
+            content.misticaBackport.accessibilityIdentifier(identifier)
         } else {
             content
         }


### PR DESCRIPTION
Hi there!

This PR is to fix a bug with the accessibilityModifier modifier which was having an infinite recursion when called due to the availability blocks inside it. This was also causing crashes in apps using this feature.

Thanks to @jmpg93 we have been able to fix the bug by using a backport to avoid this infinite loop.