### PR TITLE
IOS-7720 Fix asset size

### DIFF
--- a/MisticaCatalog/Source/Catalog/Mistica/Components/UICatalogSheetViewController.swift
+++ b/MisticaCatalog/Source/Catalog/Mistica/Components/UICatalogSheetViewController.swift
@@ -15,6 +15,7 @@ private enum Section: Int, CaseIterable {
     case description
     case numberOfElements
     case hasAsset
+    case assetSize
     case showSheet
 }
 
@@ -67,6 +68,16 @@ class UICatalogSheetViewController: UIViewController {
         return cell
     }()
 
+    private lazy var assetSizeCell: UISegmentedControlTableViewCell = {
+        let cell = UISegmentedControlTableViewCell(reuseIdentifier: "assetSize")
+
+        cell.segmentedControl.insertSegment(withTitle: "Small", at: 0, animated: false)
+        cell.segmentedControl.insertSegment(withTitle: "Large", at: 1, animated: false)
+
+        cell.segmentedControl.selectedSegmentIndex = 1
+        return cell
+    }()
+
     private lazy var showSheetCell: UITableViewCell = {
         let cell = UITableViewCell(style: .default, reuseIdentifier: "showSheet")
         cell.textLabel?.textColor = .textLink
@@ -80,6 +91,7 @@ class UICatalogSheetViewController: UIViewController {
         [descriptionCell],
         [numberOfElementsCell],
         [assetCell],
+        [assetSizeCell],
         [showSheetCell]
     ]
 
@@ -147,7 +159,13 @@ extension UICatalogSheetViewController: UITableViewDataSource, UITableViewDelega
                 id: index.description,
                 title: "Element \(index)",
                 description: "Description",
-                icon: assetCell.segmentedControl.selectedSegmentIndex == 0 ? SheetListRowIcon(url: "https://img.icons8.com/ios-glyphs/344/bookmark.png", urlDark: "https://img.icons8.com/ios/344/bookmark--v1.png") : nil
+                icon: assetCell.segmentedControl.selectedSegmentIndex == 0
+                    ? SheetListRowIcon(
+                        url: "https://img.icons8.com/ios-glyphs/344/bookmark.png",
+                        urlDark: "https://img.icons8.com/ios/344/bookmark--v1.png",
+                        size: assetSizeCell.segmentedControl.selectedSegmentIndex == 0 ? .small : .large
+                    )
+                    : nil
             )
             rows.append(item)
         }
@@ -205,6 +223,7 @@ private extension Section {
         case .description: return "Description"
         case .numberOfElements: return "Configuration"
         case .hasAsset: return "Has asset"
+        case .assetSize: return "Asset size"
         case .showSheet: return nil
         }
     }

--- a/Sources/Mistica/Components/Sheet/Model/SheetConfiguration.swift
+++ b/Sources/Mistica/Components/Sheet/Model/SheetConfiguration.swift
@@ -10,8 +10,8 @@ import Foundation
 import UIKit
 
 public struct SheetConfiguration {
-    let header: SheetHeader
-    let content: [SheetList]
+    public let header: SheetHeader
+    public let content: [SheetList]
 
     public init(header: SheetHeader,
                 content: [SheetList]) {
@@ -21,9 +21,9 @@ public struct SheetConfiguration {
 }
 
 public struct SheetHeader {
-    let title: String?
-    let subtitle: String?
-    let description: String?
+    public let title: String?
+    public let subtitle: String?
+    public let description: String?
 
     public init(title: String? = nil,
                 subtitle: String? = nil,
@@ -35,12 +35,12 @@ public struct SheetHeader {
 }
 
 public struct SheetList {
-    let id: String
-    let type: String
-    let listType: String?
-    let autoSubmit: Bool?
-    let selectedId: String?
-    let items: [SheetListRow]
+    public let id: String
+    public let type: String
+    public let listType: String?
+    public let autoSubmit: Bool?
+    public let selectedId: String?
+    public let items: [SheetListRow]
 
     public init(id: String,
                 type: String,
@@ -58,11 +58,11 @@ public struct SheetList {
 }
 
 public struct SheetListRow {
-    let id: String
-    let title: String?
-    let description: String?
-    let icon: SheetListRowIcon?
-    let isSelected: Bool
+    public let id: String
+    public let title: String?
+    public let description: String?
+    public let icon: SheetListRowIcon?
+    public let isSelected: Bool
 
     public init(id: String,
                 title: String? = nil,
@@ -92,9 +92,9 @@ public struct SheetListRowIcon {
         }
     }
 
-    let url: String
-    let urlDark: String?
-    let size: Size
+    public let url: String
+    public let urlDark: String?
+    public let size: Size
 
     public init(url: String,
                 urlDark: String? = nil,

--- a/Sources/Mistica/Components/Sheet/Model/SheetConfiguration.swift
+++ b/Sources/Mistica/Components/Sheet/Model/SheetConfiguration.swift
@@ -78,12 +78,29 @@ public struct SheetListRow {
 }
 
 public struct SheetListRowIcon {
+    public enum Size {
+        case small
+        case large
+
+        var value: CGFloat {
+            switch self {
+            case .small:
+                return 24
+            case .large:
+                return 40
+            }
+        }
+    }
+
     let url: String
     let urlDark: String?
+    let size: Size
 
     public init(url: String,
-                urlDark: String? = nil) {
+                urlDark: String? = nil,
+                size: Size = .large) {
         self.url = url
         self.urlDark = urlDark
+        self.size = size
     }
 }

--- a/Sources/Mistica/Components/Sheet/View/SheetView.swift
+++ b/Sources/Mistica/Components/Sheet/View/SheetView.swift
@@ -132,8 +132,8 @@ private extension SheetView {
 
                 if let icon = item.icon {
                     let imageView = UIImageView()
-                    imageView.heightAnchor.constraint(equalToConstant: 24.0).isActive = true
-                    imageView.widthAnchor.constraint(equalToConstant: 24.0).isActive = true
+                    imageView.heightAnchor.constraint(equalToConstant: 40.0).isActive = true
+                    imageView.widthAnchor.constraint(equalToConstant: 40.0).isActive = true
                     imageView.contentMode = .scaleAspectFit
                     if let url = URL(string: icon.url),
                        let data = try? Data(contentsOf: url) {

--- a/Sources/Mistica/Components/Sheet/View/SheetView.swift
+++ b/Sources/Mistica/Components/Sheet/View/SheetView.swift
@@ -132,8 +132,8 @@ private extension SheetView {
 
                 if let icon = item.icon {
                     let imageView = UIImageView()
-                    imageView.heightAnchor.constraint(equalToConstant: 40.0).isActive = true
-                    imageView.widthAnchor.constraint(equalToConstant: 40.0).isActive = true
+                    imageView.heightAnchor.constraint(equalToConstant: icon.size.value).isActive = true
+                    imageView.widthAnchor.constraint(equalToConstant: icon.size.value).isActive = true
                     imageView.contentMode = .scaleAspectFit
                     if let url = URL(string: icon.url),
                        let data = try? Data(contentsOf: url) {


### PR DESCRIPTION
Following the specs:
![Captura de Pantalla 2022-09-23 a las 8 33 52](https://user-images.githubusercontent.com/9945756/191904030-c2c15746-63fe-49df-90cc-af8ab2ce03fa.png)
https://www.figma.com/file/nxToAYk7FGC86TS0mY61TU/Sheet?node-id=1697%3A9481

It was wrong:
![Captura de Pantalla 2022-09-22 a las 18 23 37](https://user-images.githubusercontent.com/9945756/191904070-0d50508d-49cd-41b0-9fd1-6a5c3a86a1f9.png)

But now it's
![Captura de Pantalla 2022-09-23 a las 8 33 32](https://user-images.githubusercontent.com/9945756/191904103-c2e1eb1b-c6e7-4db0-9350-b111eebb739b.png)

How??? I've added the two sizes to show an icon: 24x24 & 40x40. By default it will be 40x40 (copying the current behavior of the list cells)
