### PR TITLE
IOS-7902 add a customisable time interval to dismiss

### DIFF
--- a/MisticaCatalog/Source/Catalog/Mistica/Components/UICatalogCroutonViewController.swift
+++ b/MisticaCatalog/Source/Catalog/Mistica/Components/UICatalogCroutonViewController.swift
@@ -44,11 +44,21 @@ class UICatalogCroutonViewController: UITableViewController {
         cell.textLabel?.text = "Show Crouton"
         return cell
     }()
+    
+    private lazy var croutonDismissIntervalCell: UISegmentedControlTableViewCell = {
+        let cell = UISegmentedControlTableViewCell(reuseIdentifier: "crouton-dismiss-interval")
+        for interval in  CroutonDismissInterval.allCases {
+            cell.segmentedControl.insertSegment(withTitle: "\(interval.rawValue) seconds", at: 0, animated: false)
+        }
+        cell.segmentedControl.selectedSegmentIndex = 0
+        return cell
+    }()
 
     private lazy var cells = [
         [titleCell],
         [actionTitleCell],
-        [croutonStyleCell, showCroutonCell]
+        [croutonStyleCell],
+        [croutonDismissIntervalCell, showCroutonCell]
     ]
 
     init() {
@@ -99,7 +109,8 @@ extension UICatalogCroutonViewController {
             CroutonController.shared.showCrouton(
                 withText: titleCell.textField.text ?? "",
                 action: croutonAction,
-                style: selectedCroutonStyle
+                style: selectedCroutonStyle,
+                croutonDismissInterval: croutonDismissInterval
             )
         } else {
             let sampleTabBarViewController = SampleTabBarViewController()
@@ -122,6 +133,11 @@ private extension UICatalogCroutonViewController {
         guard let title = actionTitleCell.textField.text, !title.isEmpty else { return nil }
         return CroutonController.ActionConfig(text: title, handler: { print("Crouton Action Tapped") })
     }
+    
+    var croutonDismissInterval: CroutonDismissInterval? {
+        let selectedCroutonDismissIntervalIndex = croutonDismissIntervalCell.segmentedControl.selectedSegmentIndex
+        return CroutonDismissInterval(rawValue: selectedCroutonDismissIntervalIndex)
+    }
 }
 
 private extension CroutonStyle {
@@ -141,6 +157,19 @@ private extension Section {
         case .title: return "Title"
         case .action: return "Action Title"
         case .show, .showInTab: return nil
+        }
+    }
+}
+
+extension CroutonDismissInterval {
+    public init?(rawValue: Int) {
+        switch rawValue {
+        case 0:
+            self = .tenSeconds
+        case 1:
+            self = .fiveSeconds
+        default:
+            return nil
         }
     }
 }

--- a/MisticaCatalog/Source/Catalog/Mistica/Components/UICatalogCroutonViewController.swift
+++ b/MisticaCatalog/Source/Catalog/Mistica/Components/UICatalogCroutonViewController.swift
@@ -44,10 +44,10 @@ class UICatalogCroutonViewController: UITableViewController {
         cell.textLabel?.text = "Show Crouton"
         return cell
     }()
-    
+
     private lazy var croutonDismissIntervalCell: UISegmentedControlTableViewCell = {
         let cell = UISegmentedControlTableViewCell(reuseIdentifier: "crouton-dismiss-interval")
-        for interval in  CroutonDismissInterval.allCases {
+        for interval in CroutonDismissInterval.allCases {
             cell.segmentedControl.insertSegment(withTitle: "\(interval.rawValue) seconds", at: 0, animated: false)
         }
         cell.segmentedControl.selectedSegmentIndex = 0
@@ -133,7 +133,7 @@ private extension UICatalogCroutonViewController {
         guard let title = actionTitleCell.textField.text, !title.isEmpty else { return nil }
         return CroutonController.ActionConfig(text: title, handler: { print("Crouton Action Tapped") })
     }
-    
+
     var croutonDismissInterval: CroutonDismissInterval? {
         let selectedCroutonDismissIntervalIndex = croutonDismissIntervalCell.segmentedControl.selectedSegmentIndex
         return CroutonDismissInterval(rawValue: selectedCroutonDismissIntervalIndex)
@@ -161,8 +161,8 @@ private extension Section {
     }
 }
 
-extension CroutonDismissInterval {
-    public init?(rawValue: Int) {
+public extension CroutonDismissInterval {
+    init?(rawValue: Int) {
         switch rawValue {
         case 0:
             self = .tenSeconds

--- a/Sources/Mistica/Components/Crouton/Domain/CroutonConfig.swift
+++ b/Sources/Mistica/Components/Crouton/Domain/CroutonConfig.swift
@@ -14,12 +14,25 @@ import UIKit
     case critical
 }
 
+public enum CroutonDismissInterval: Int, CaseIterable {
+    case fiveSeconds = 5
+    case tenSeconds = 10
+}
+
+public extension CroutonDismissInterval {
+    var timeInterval: TimeInterval {
+        TimeInterval(self.rawValue)
+    }
+}
+
+
 public struct CroutonConfig {
     let backgroundColor: UIColor
     let textColor: UIColor
     let actionStyle: Button.Style
+    let overrideDismissInterval: TimeInterval?
 
-    public init(style: CroutonStyle) {
+    public init(style: CroutonStyle, croutonDismissInterval: CroutonDismissInterval? = nil) {
         switch style {
         case .info:
             backgroundColor = .feedbackInfoBackground
@@ -30,6 +43,7 @@ public struct CroutonConfig {
             textColor = .textPrimaryInverse
             actionStyle = .croutonCriticalLink
         }
+        overrideDismissInterval = croutonDismissInterval?.timeInterval
     }
 }
 

--- a/Sources/Mistica/Components/Crouton/Domain/CroutonConfig.swift
+++ b/Sources/Mistica/Components/Crouton/Domain/CroutonConfig.swift
@@ -21,10 +21,9 @@ public enum CroutonDismissInterval: Int, CaseIterable {
 
 public extension CroutonDismissInterval {
     var timeInterval: TimeInterval {
-        TimeInterval(self.rawValue)
+        TimeInterval(rawValue)
     }
 }
-
 
 public struct CroutonConfig {
     let backgroundColor: UIColor

--- a/Sources/Mistica/Components/Crouton/Presentation/CroutonController.swift
+++ b/Sources/Mistica/Components/Crouton/Presentation/CroutonController.swift
@@ -39,14 +39,16 @@ public extension CroutonController {
         withText text: String,
         action: ActionConfig? = nil,
         style: CroutonStyle = .info,
-        dismissHandler: DismissHandlerBlock? = nil
+        dismissHandler: DismissHandlerBlock? = nil,
+        croutonDismissInterval: CroutonDismissInterval? = nil
     ) -> Token {
         showCrouton(
             withText: text,
             action: action,
             style: style,
             dismissHandler: dismissHandler,
-            rootViewController: UIApplication.shared.windows.filter(\.isKeyWindow).first?.rootViewController
+            rootViewController: UIApplication.shared.windows.filter(\.isKeyWindow).first?.rootViewController,
+            croutonDismissInterval: croutonDismissInterval
         )
     }
 
@@ -63,11 +65,12 @@ public extension CroutonController {
         action: ActionConfig? = nil,
         style: CroutonStyle = .info,
         dismissHandler: DismissHandlerBlock? = nil,
-        rootViewController: @escaping @autoclosure () -> UIViewController?
+        rootViewController: @escaping @autoclosure () -> UIViewController?,
+        croutonDismissInterval: CroutonDismissInterval? = nil
     ) -> Token {
         assertMainThread()
 
-        let config = CroutonConfig(style: style)
+        let config = CroutonConfig(style: style, croutonDismissInterval: croutonDismissInterval)
 
         let dismissHandler = {
             self.dismissCurrentCrouton()

--- a/Sources/Mistica/Components/Crouton/Presentation/CroutonView.swift
+++ b/Sources/Mistica/Components/Crouton/Presentation/CroutonView.swift
@@ -252,8 +252,13 @@ private extension CroutonView {
     }
 
     func addCountdownToDismiss() {
-        let dismissInterval = (action == nil) ? Constants.actionlessDismissInterval
-            : Constants.withActionDismissInterval
+        let dismissInterval: TimeInterval
+        if let overrideDismissInterval = config.overrideDismissInterval {
+            dismissInterval = overrideDismissInterval
+        } else {
+            dismissInterval = (action == nil) ? Constants.actionlessDismissInterval
+                : Constants.withActionDismissInterval
+        }
 
         timer = Timer.scheduledTimer(
             timeInterval: dismissInterval,


### PR DESCRIPTION
https://jira.tid.es/browse/IOS-7902

This PR consists of adding the possibility to customize the time it takes for the Crouton component to disappear. By default, the time for a Crouton without actions is five seconds, and sometimes that may not seem long enough, for example when showing a warning to the user that he has no connection. 

What I have done is give freedom to the developer to choose that time for any style of Crouton. The design team they have proposed to provide a choice between 5 and 10 seconds.