### PR TITLE
refactor(MisticaButton): Added public access level to MisticaButton and style

### DIFF
--- a/Sources/MisticaSwiftUI/Components/Button/MisticaButton.swift
+++ b/Sources/MisticaSwiftUI/Components/Button/MisticaButton.swift
@@ -13,7 +13,7 @@ public enum ButtonBleedingAlignment {
 }
 
 @available(iOS 13.0, *)
-struct MisticaButton: View {
+public struct MisticaButton: View {
     enum Constants {
         static let minWidth: CGFloat = 76
         static let height: CGFloat = 24

--- a/Sources/MisticaSwiftUI/Components/Button/MisticaButton.swift
+++ b/Sources/MisticaSwiftUI/Components/Button/MisticaButton.swift
@@ -58,15 +58,35 @@ public struct MisticaButton: View {
     }
 
     public struct StateStyle {
-        public let textColor: Color
-        public let backgroundColor: Color
-        public let borderColor: Color
+        let textColor: Color
+        let backgroundColor: Color
+        let borderColor: Color
+        
+        public init(
+            textColor: Color,
+            backgroundColor: Color,
+            borderColor: Color
+        ) {
+            self.textColor = textColor
+            self.backgroundColor = backgroundColor
+            self.borderColor = borderColor
+        }
     }
 
     let configuration: ButtonStyle.Configuration
     let style: Style
     let small: Bool
 
+    public init(
+        configuration: ButtonStyle.Configuration,
+        style: Style,
+        small: Bool
+    ) {
+        self.configuration = configuration
+        self.style = style
+        self.small = small
+    }
+    
     @Environment(\.misticaButtonLoadingInfo) private var loadingInfo
     @Environment(\.isEnabled) private var isEnabled
 

--- a/Sources/MisticaSwiftUI/Components/Button/MisticaButton.swift
+++ b/Sources/MisticaSwiftUI/Components/Button/MisticaButton.swift
@@ -61,7 +61,7 @@ public struct MisticaButton: View {
         let textColor: Color
         let backgroundColor: Color
         let borderColor: Color
-        
+
         public init(
             textColor: Color,
             backgroundColor: Color,
@@ -86,7 +86,7 @@ public struct MisticaButton: View {
         self.style = style
         self.small = small
     }
-    
+
     @Environment(\.misticaButtonLoadingInfo) private var loadingInfo
     @Environment(\.isEnabled) private var isEnabled
 

--- a/Sources/MisticaSwiftUI/Components/Button/MisticaButton.swift
+++ b/Sources/MisticaSwiftUI/Components/Button/MisticaButton.swift
@@ -25,11 +25,11 @@ public struct MisticaButton: View {
         static let transitionOffset: CGFloat = 40
     }
 
-    enum ButtonState {
+    public enum ButtonState {
         case normal, selected, disabled, loading
     }
 
-    struct Style {
+    public struct Style {
         let bleedingAlignment: ButtonBleedingAlignment
         let styleByState: [ButtonState: StateStyle]
         let hasMinWidth: Bool
@@ -57,7 +57,7 @@ public struct MisticaButton: View {
         }
     }
 
-    struct StateStyle {
+    public struct StateStyle {
         let textColor: Color
         let backgroundColor: Color
         let borderColor: Color

--- a/Sources/MisticaSwiftUI/Components/Button/MisticaButton.swift
+++ b/Sources/MisticaSwiftUI/Components/Button/MisticaButton.swift
@@ -34,7 +34,7 @@ public struct MisticaButton: View {
         let styleByState: [ButtonState: StateStyle]
         let hasMinWidth: Bool
 
-        init(
+        public init(
             bleedingAlignment: ButtonBleedingAlignment = .none,
             hasMinWidth: Bool = true,
             styleByState: [ButtonState: StateStyle]
@@ -58,9 +58,9 @@ public struct MisticaButton: View {
     }
 
     public struct StateStyle {
-        let textColor: Color
-        let backgroundColor: Color
-        let borderColor: Color
+        public let textColor: Color
+        public let backgroundColor: Color
+        public let borderColor: Color
     }
 
     let configuration: ButtonStyle.Configuration

--- a/Sources/MisticaSwiftUI/Components/Button/MisticaButtonStyle.swift
+++ b/Sources/MisticaSwiftUI/Components/Button/MisticaButtonStyle.swift
@@ -22,7 +22,7 @@ public struct MisticaButtonStyle: ButtonStyle {
         self.style = style
         self.small = small
     }
-    
+
     public func makeBody(configuration: Configuration) -> some View {
         MisticaButton(configuration: configuration, style: style, small: small)
     }

--- a/Sources/MisticaSwiftUI/Components/Button/MisticaButtonStyle.swift
+++ b/Sources/MisticaSwiftUI/Components/Button/MisticaButtonStyle.swift
@@ -15,6 +15,14 @@ public struct MisticaButtonStyle: ButtonStyle {
     let style: MisticaButton.Style
     let small: Bool
 
+    public init(
+        style: MisticaButton.Style,
+        small: Bool
+    ) {
+        self.style = style
+        self.small = small
+    }
+    
     public func makeBody(configuration: Configuration) -> some View {
         MisticaButton(configuration: configuration, style: style, small: small)
     }


### PR DESCRIPTION
In order to have custom MisticaButton styles we need to access the initializer

![Screenshot 2022-12-02 at 11 41 59](https://user-images.githubusercontent.com/216846/205274930-db3e4151-7eb1-4547-9bb0-ec06b79bcfcf.png)
