### PR TITLE
Force semantic release and node versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,12 +21,12 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3.5.0
         with:
-          node-version: 14.17
+          node-version: 18.0
 
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.NOVUM_PRIVATE_REPOS }}
-        run: npx -p @semantic-release/changelog -p @semantic-release/git -p @semantic-release/exec -p semantic-release semantic-release ${{ github.event.inputs.cliArgs }}
+        run: npx -p @semantic-release/changelog -p @semantic-release/git -p @semantic-release/exec -p semantic-release semantic-release@20 ${{ github.event.inputs.cliArgs }}
 
       - name: Checkout Telefonica/github-actions repo
         uses: actions/checkout@v3.1.0


### PR DESCRIPTION
In order not to have problems with semantic release versions and its dependency to Node, both have been forced to use specific versions.

Semantic-release has been forced to use 20.x.x version as before it was using latest version released.
Node has been forced to use 18.0.x version as is the LTS supported by semantic-release 20.0.x 

<img width="887" alt="Captura de Pantalla 2023-01-10 a las 12 20 44" src="https://user-images.githubusercontent.com/14164533/211538033-fdbefc3c-73b5-41be-9cdd-0578c2ad829c.png">

