### PR TITLE
IOS-8133 Fix compilation error for Xcode 14.3 beta 2

### DIFF
--- a/Sources/MisticaSwiftUI/Components/Cards/DataCard.swift
+++ b/Sources/MisticaSwiftUI/Components/Cards/DataCard.swift
@@ -116,15 +116,13 @@ public struct DataCard<Headline: View, Fragment: View, PrimaryButton: View, Link
                         .buttonStyle(.misticaPrimary(small: true))
                 }
 
-                if let linkButton = linkButton {
-                    linkButton
-                        .buttonStyle(
-                            .misticaLink(
-                                small: true,
-                                bleedingAlignment: hasPrimaryButton ? .none : .leading
-                            )
+                linkButton
+                    .buttonStyle(
+                        .misticaLink(
+                            small: true,
+                            bleedingAlignment: hasPrimaryButton ? .none : .leading
                         )
-                }
+                    )
             }
             .padding(.top, 16)
         }


### PR DESCRIPTION
Xcode 14.3 beta 2 is triggering a compilation error in DataCard component, due to we're using an optional binding with a non optional value.

<img width="889" alt="Screenshot 2023-02-28 at 23 22 04" src="https://user-images.githubusercontent.com/125256346/222412859-9736f9ea-f69f-4a22-9442-7a42d6eb603c.png">
