### PR TITLE
IOS-8146 Fix ListCellContent cell registered with new Mistica version

### DIFF
--- a/MisticaCatalog/Source/Catalog/Mistica/Components/UICatalogCardsViewController.swift
+++ b/MisticaCatalog/Source/Catalog/Mistica/Components/UICatalogCardsViewController.swift
@@ -93,7 +93,7 @@ private extension UICatalogCardsViewController {
 
         tableView.dataSource = self
         tableView.delegate = self
-        tableView.register(ListCellContentView.self, forCellReuseIdentifier: Constants.cellReusableIdentifier)
+        tableView.register(ListTableViewCell.self, forCellReuseIdentifier: Constants.cellReusableIdentifier)
     }
 }
 

--- a/MisticaCatalog/Source/Catalog/Mistica/Components/UICatalogSectionTitleViewController.swift
+++ b/MisticaCatalog/Source/Catalog/Mistica/Components/UICatalogSectionTitleViewController.swift
@@ -52,7 +52,7 @@ class UICatalogSectionTitleViewController: UITableViewController {
         tableView.tableFooterView = UIView(frame: CGRect.zero)
         tableView.sectionFooterHeight = 0.0
 
-        tableView.register(ListCellContentView.self, forCellReuseIdentifier: Constants.listCellReusableIdentifier)
+        tableView.register(ListTableViewCell.self, forCellReuseIdentifier: Constants.listCellReusableIdentifier)
         tableView.register(TitleView.self, forHeaderFooterViewReuseIdentifier: Constants.sectionTitleReusableIdentifier)
     }
 


### PR DESCRIPTION
Hi there! 👋

With the recent breaking changes in the 21.0.0 version of Mistica: https://github.com/Telefonica/mistica-ios/compare/v20.2.0...v21.0.0

The TableViewCell named ListViewCell has been renamed to ListTableViewCell. Therefore, it is necessary to update two cell registers that were outdated with the last change and made the Catalog not work properly.