### PR TITLE
Allow building alphas in Mistica

### DIFF
--- a/.github/workflows/build-mistica-catalog.yml
+++ b/.github/workflows/build-mistica-catalog.yml
@@ -1,26 +1,37 @@
 name: Deploy Mistica Catalog
 
 on:
-  release:
-    types: [published]
+  push:
   workflow_dispatch:
         inputs:
             app-center-project:
               description: 'App Center app name'
               type: choice
               options:
-              # Internal Enterprise:
-              - Mistica-iOS
-              # Alpha:
-              - Mistica-SwiftUI-iOS
+              - "Internal Enterprise (iOS-Apps-Core-Misc)"
+              - "Alpha (Mistica-SwiftUI-iOS)"
               required: true
 
 jobs:
   deploy-mistica-catalog:
     name: Build enterprise
     runs-on: self-hosted-novum-mac
-
     steps:
+      - name: Set configuration variables
+        shell: bash
+        run: |
+          echo "::group::Setting variables..."
+          if [ "${{ github.event.inputs.app-center-project }}" = "Internal Enterprise (iOS-Apps-Core-Misc)" ]; then
+              echo 'APP_CENTER_PROJECT=iOS-Apps-Core-Misc' >> $GITHUB_OUTPUT
+          elif [ "${{ github.event.inputs.app-center-project }}" = "Alpha (Mistica-SwiftUI-iOS)" ]; then
+              echo 'APP_CENTER_PROJECT=Mistica-SwiftUI-iOS' >> $GITHUB_OUTPUT
+          else
+              # Default value for automatic triggers like `release, `push`, ...
+              echo 'APP_CENTER_PROJECT=iOS-Apps-Core-Misc' >> $GITHUB_OUTPUT
+          fi
+          echo "::endgroup::"
+        id: variables
+
       - name: Checkout
         uses: actions/checkout@v3.1.0
 
@@ -49,5 +60,5 @@ jobs:
           node-version: 18.13.0
 
       - name: Upload ipa to AppCenter
-        run: npx -p appcenter-cli appcenter distribute release -a Tuenti-Organization/${{ github.event.inputs.app-center-project || 'Mistica-iOS' }} -f ./build/ios.ipa -g Public --token ${{ secrets.APPCENTER_API_TOKEN }}
+        run: npx -p appcenter-cli appcenter distribute release -a Tuenti-Organization/${{ steps.variables.outputs.APP_CENTER_PROJECT }} -f ./build/ios.ipa -g Public --token ${{ secrets.APPCENTER_API_TOKEN }}
 

--- a/.github/workflows/build-mistica-catalog.yml
+++ b/.github/workflows/build-mistica-catalog.yml
@@ -1,7 +1,8 @@
 name: Deploy Mistica Catalog
 
 on:
-  push:
+  release:
+    types: [published]
   workflow_dispatch:
         inputs:
             app-center-project:
@@ -48,5 +49,5 @@ jobs:
           node-version: 18.13.0
 
       - name: Upload ipa to AppCenter
-        run: npx -p appcenter-cli appcenter distribute release -a Tuenti-Organization/${{ github.event.inputs.app-center-project || 'Mistica-SwiftUI-iOS' }} -f ./build/ios.ipa -g Public --token ${{ secrets.APPCENTER_API_TOKEN }}
+        run: npx -p appcenter-cli appcenter distribute release -a Tuenti-Organization/${{ github.event.inputs.app-center-project || 'Mistica-iOS' }} -f ./build/ios.ipa -g Public --token ${{ secrets.APPCENTER_API_TOKEN }}
 

--- a/.github/workflows/build-mistica-catalog.yml
+++ b/.github/workflows/build-mistica-catalog.yml
@@ -1,8 +1,7 @@
 name: Deploy Mistica Catalog
 
 on:
-  release:
-    types: [published]
+  push:
   workflow_dispatch:
         inputs:
             app-center-project:
@@ -49,5 +48,5 @@ jobs:
           node-version: 18.13.0
 
       - name: Upload ipa to AppCenter
-        run: npx -p appcenter-cli appcenter distribute release -a Tuenti-Organization/${{ github.event.inputs.app-center-project || 'Mistica-iOS' }} -f ./build/ios.ipa -g Public --token ${{ secrets.APPCENTER_API_TOKEN }}
+        run: npx -p appcenter-cli appcenter distribute release -a Tuenti-Organization/${{ github.event.inputs.app-center-project || 'Mistica-SwiftUI-iOS' }} -f ./build/ios.ipa -g Public --token ${{ secrets.APPCENTER_API_TOKEN }}
 

--- a/.github/workflows/build-mistica-catalog.yml
+++ b/.github/workflows/build-mistica-catalog.yml
@@ -1,14 +1,15 @@
 name: Deploy Mistica Catalog
 
 on:
-  push:
+  release:
+    types: [published]
   workflow_dispatch:
         inputs:
             app-center-project:
               description: 'App Center app name'
               type: choice
               options:
-              - "Internal Enterprise (iOS-Apps-Core-Misc)"
+              - "Internal Enterprise (Mistica-iOS)"
               - "Alpha (Mistica-SwiftUI-iOS)"
               required: true
 
@@ -21,13 +22,13 @@ jobs:
         shell: bash
         run: |
           echo "::group::Setting variables..."
-          if [ "${{ github.event.inputs.app-center-project }}" = "Internal Enterprise (iOS-Apps-Core-Misc)" ]; then
-              echo 'APP_CENTER_PROJECT=iOS-Apps-Core-Misc' >> $GITHUB_OUTPUT
+          if [ "${{ github.event.inputs.app-center-project }}" = "Internal Enterprise (Mistica-iOS)" ]; then
+              echo 'APP_CENTER_PROJECT=Mistica-iOS' >> $GITHUB_OUTPUT
           elif [ "${{ github.event.inputs.app-center-project }}" = "Alpha (Mistica-SwiftUI-iOS)" ]; then
               echo 'APP_CENTER_PROJECT=Mistica-SwiftUI-iOS' >> $GITHUB_OUTPUT
           else
               # Default value for automatic triggers like `release, `push`, ...
-              echo 'APP_CENTER_PROJECT=iOS-Apps-Core-Misc' >> $GITHUB_OUTPUT
+              echo 'APP_CENTER_PROJECT=Mistica-iOS' >> $GITHUB_OUTPUT
           fi
           echo "::endgroup::"
         id: variables

--- a/.github/workflows/build-mistica-catalog.yml
+++ b/.github/workflows/build-mistica-catalog.yml
@@ -5,10 +5,15 @@ on:
     types: [published]
   workflow_dispatch:
         inputs:
-            commit_to_deploy:
-                description: 'Changeset'
-                required: false
-                default: ''
+            app-center-project:
+              description: 'App Center app name'
+              type: choice
+              options:
+              # Internal Enterprise:
+              - Mistica-iOS
+              # Alpha:
+              - Mistica-SwiftUI-iOS
+              required: true
 
 jobs:
   deploy-mistica-catalog:
@@ -44,5 +49,5 @@ jobs:
           node-version: 18.13.0
 
       - name: Upload ipa to AppCenter
-        run: npx -p appcenter-cli appcenter distribute release -a Tuenti-Organization/Mistica-iOS -f ./build/ios.ipa -g Public --token ${{ secrets.APPCENTER_API_TOKEN }}
+        run: npx -p appcenter-cli appcenter distribute release -a ${{ github.event.inputs.app-center-project || 'Mistica-iOS' }} -f ./build/ios.ipa -g Public --token ${{ secrets.APPCENTER_API_TOKEN }}
   

--- a/.github/workflows/build-mistica-catalog.yml
+++ b/.github/workflows/build-mistica-catalog.yml
@@ -49,5 +49,5 @@ jobs:
           node-version: 18.13.0
 
       - name: Upload ipa to AppCenter
-        run: npx -p appcenter-cli appcenter distribute release -a ${{ github.event.inputs.app-center-project || 'Mistica-iOS' }} -f ./build/ios.ipa -g Public --token ${{ secrets.APPCENTER_API_TOKEN }}
-  
+        run: npx -p appcenter-cli appcenter distribute release -a Tuenti-Organization/${{ github.event.inputs.app-center-project || 'Mistica-iOS' }} -f ./build/ios.ipa -g Public --token ${{ secrets.APPCENTER_API_TOKEN }}
+


### PR DESCRIPTION
# Problem
We want to create builds to be tested by Design, Devs, etc **before integrating the feature**.
The AppCenter project is hardcoded in [build-mistica-catalog](https://github.com/Telefonica/mistica-ios/blob/main/.github/workflows/build-mistica-catalog.yml#L47) and using 
![Screenshot 2023-03-10 at 13 57 03](https://user-images.githubusercontent.com/9945756/224321735-e8d29a16-da51-4653-b2fc-a84d22589cff.png)
will override our _Internal Enterprise_.

# Solution
1. Create a new appCenter project (I took an existing one): https://appcenter.ms/orgs/Tuenti-Organization/apps/Mistica-SwiftUI-iOS
2. Parametrize the project (See this PR)

## How I've tested
### Manual generation (`workflow_dispatch`)
I've executed 
![Screenshot 2023-03-10 at 14 00 10](https://user-images.githubusercontent.com/9945756/224322326-6ba0935d-fe75-4a1f-bd45-e714fa93452b.png)
and it created
https://appcenter.ms/orgs/Tuenti-Organization/apps/Mistica-SwiftUI-iOS/distribute/releases/7
Action: https://github.com/Telefonica/mistica-ios/actions/runs/4384647422

### Automatic generation (`release`)
To avoid forcing a release in a different branch, I've replaced the trigger with `push` (https://github.com/Telefonica/mistica-ios/pull/258/commits/4f6e6c0499caf4272b52d4a1f60f61cf9122488e) and the default value (to avoid overriding the _Internal Enterprise_).
It created https://appcenter.ms/orgs/Tuenti-Organization/apps/Mistica-SwiftUI-iOS/distribute/releases/8
Action: https://github.com/Telefonica/mistica-ios/actions/runs/4384669203
Obviously I've reverted that https://github.com/Telefonica/mistica-ios/pull/258/commits/62c3b4e71688fb386be684f32d841f13f13ac72a