### PR TITLE
IOS-8208 Add MisticaCatalog config to be pushed with the version bumped

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,23 @@
+## 🎟️ **Jira ticket**
+<!-- Add here the ticket number: [IOS-XXXX](https://jira.tid.es/browse/IOS-XXX) Blah Blah -->
+
+## 🥅 **What's the goal?**
+<!--
+Here is a description of what this pull request is about, with a brief text of the functionality or bug to be fixed. Use the following points to help you:
+- Attach screenshots or videos to describe what you want to fix.
+- If this ticket is part of a previous pull request or is related to other tickets, this is a good place to add the links.
+-->
+
+## 🚧 **How do we do it?**
+<!--
+Provide a description of the solution you have implemented.
+- A list of steps would be ideal
+- Indicate which files have the important changes
+- You can indicate which files have trivial changes or which ones are not necessary to test. 
+- May be this could be a good place to describe how the feature is tested (unit or UI) or justify the lack of tests if there is no one
+-->
+
+## 🧪 **How can I verify this?**
+<!-- Adding some screenshots/gifs in order to demonstrate that it works could ease its verification. If it cannot be tested explain why. -->
+
+## 🏑 **AppCenter build**

--- a/.releaserc
+++ b/.releaserc
@@ -7,7 +7,7 @@
             "prepareCmd": "./scripts/update-version.sh ${nextRelease.version}"
         }],
         ["@semantic-release/git", {
-            "assets": ["CHANGELOG.md", "Mistica.podspec", "MisticaSwiftUI.podspec", "Sources/SupportFiles/Mistica.xcconfig", "MisticaCatalog/SupportFiles/Config.xcconfig"]
+            "assets": ["CHANGELOG.md", "Sources/SupportFiles/Mistica.xcconfig", "MisticaCatalog/SupportFiles/MisticaCatalogConfig.xcconfig"]
         }],
         "@semantic-release/github"
     ],


### PR DESCRIPTION
## 🎟️ **Jira ticket**
https://jira.tid.es/browse/IOS-8208

## 🥅 **What's the goal?**
Every release, the Mistica Catalog must be bumped as Mistica already does. Currently, Mistica Catalog version is not pushed.
![Captura de pantalla 2023-03-17 a las 12 34 03](https://user-images.githubusercontent.com/9945756/225895811-424adeb6-0eca-43dd-b844-7773ecb1f9ee.png)

## 🚧 **How do we do it?**
The problem is here:
https://github.com/Telefonica/mistica-ios/blob/274db414e3e1dee34e4cb3232b01f57d452cffe7/.releaserc#L9-L11

Every time the semantic-release is executed, it modifies both xcconfigs (Catalog & Mistica), bumping to the next version.
The problem is the Catalog xcconfig is not included there, then it is not pushed :(
See https://github.com/Telefonica/mistica-ios/actions/runs/4446829704/jobs/7807625092#step:4:135 which found only two files (Changelog.md & Mistica.xcconfig).

I've just added the Catalog config.

## 🧪 **How can I verify this?**
You can check that `./scripts/update-version.sh 1.2.3` is working properly, modifying both files. We'll check it in the next release if they are commited & pushed.