### PR TITLE
IOS-8817 Allow custom font weights

### DIFF
--- a/MisticaCatalog/Source/ColorsView.swift
+++ b/MisticaCatalog/Source/ColorsView.swift
@@ -50,7 +50,7 @@ struct ColorsView: View {
             return O2ColorPalette()
         case .vivo:
             return VivoColorPalette()
-        case .custom(let colors, _):
+        case .custom(let colors, _, _):
             return colors
         }
     }

--- a/Sources/MisticaCommon/MisticaConfig.swift
+++ b/Sources/MisticaCommon/MisticaConfig.swift
@@ -48,9 +48,10 @@ private extension MisticaConfig {
             currentColors = BlauColors()
             currentBrandAssets = DefaultMisticaBrandAssets()
             currentFontWeights = BlauFontWeights()
-        case .custom(let colors, let assets):
+        case .custom(let colors, let assets, let fontWeights):
             currentColors = colors
             currentBrandAssets = assets
+            currentFontWeights = fontWeights
         }
     }
 }

--- a/Sources/MisticaCommon/Styles/BrandStyle.swift
+++ b/Sources/MisticaCommon/Styles/BrandStyle.swift
@@ -14,7 +14,7 @@ public enum BrandStyle {
     case vivo
     case o2
     case blau
-    case custom(MisticaColors, MisticaBrandAssets)
+    case custom(MisticaColors, MisticaBrandAssets, MisticaFontWeights)
 
     public var id: String {
         switch self {


### PR DESCRIPTION
## 🎟️ **Jira ticket**
https://jira.tid.es/browse/IOS-8817

## 🥅 **What's the goal?**
Allow customizing font weighs for custom mistica config like we already do for Colors and Assets. See how Zeus is configured:
https://github.com/Telefonica/zeus-ios/blob/5bc3f2963d0308a5d54f18f7f46e4cb68a4af0cd/App/iOS/AppDelegate.swift#L33

## 🚧 **How do we do it?**
Add a new associated value in `.custom` enum case.

## 🧪 **How can I verify this?**
Executed in Zeus:
![Captura de pantalla 2023-05-03 a las 16 16 08](https://user-images.githubusercontent.com/9945756/235942793-2efd3003-41b2-4340-8a9c-34b02d67d675.png)

Before it was (MovES):
![Captura de pantalla 2023-05-03 a las 16 17 07](https://user-images.githubusercontent.com/9945756/235943119-a17fb2f1-4995-473f-83f6-b977e72ae856.png)
