### PR TITLE
IOS-8932 - Make visible to accessibility HighlightedCard button

### DIFF
--- a/Sources/Mistica/Components/Cards/HighlightedCard.swift
+++ b/Sources/Mistica/Components/Cards/HighlightedCard.swift
@@ -31,7 +31,6 @@ public class HighlightedCard: UIView {
         case secondary
     }
 
-    private lazy var cardAccessibilityElement = UIAccessibilityElement(accessibilityContainer: self)
     private lazy var verticalStackView = UIStackView()
     private lazy var horizontalStackView = UIStackView()
 
@@ -143,11 +142,8 @@ public class HighlightedCard: UIView {
 
     override public var accessibilityElements: [Any]? {
         get {
-            updateAccessibilityLabel()
-            // We must set the frame and be sure it is already calculated.
-            cardAccessibilityElement.accessibilityFrameInContainerSpace = bounds
-            return [
-                cardAccessibilityElement,
+            [
+                horizontalStackView,
                 actionButton.isHidden ? nil : actionButton,
                 closeButton.isHidden ? nil : closeButton
             ].compactMap { $0 }
@@ -313,15 +309,6 @@ public extension HighlightedCard {
             backgroundImageView.accessibilityIdentifier = newValue
         }
     }
-
-    override var accessibilityTraits: UIAccessibilityTraits {
-        get {
-            cardAccessibilityElement.accessibilityTraits
-        }
-        set {
-            cardAccessibilityElement.accessibilityTraits = newValue
-        }
-    }
 }
 
 // MARK: Private
@@ -472,12 +459,5 @@ private extension HighlightedCard {
 
     @objc func actionButtonTapped() {
         actionButtonCallback?()
-    }
-
-    func updateAccessibilityLabel() {
-        cardAccessibilityElement.accessibilityLabel = [
-            titleAccessibilityLabel,
-            subtitleAccessibilityLabel
-        ].compactMap { $0 }.joined(separator: " ")
     }
 }


### PR DESCRIPTION
## 🎟️ **Jira ticket**
[IOS-8932](https://jira.tid.es/browse/IOS-8932)

## 🥅 **What's the goal?**
Make the button and labels visible for accessibility.


## 🚧 **How do we do it?**
For an old reason, we were concatenating the title and subtitle in one `UIAccessibilityElement`. I talked with the QA team and in Android they have the title and subtitle separated, and this is reasonable and expected according to Figma. So we removed the `cardAccessibilityElement` and added the `horizontalStackView`to the `accessibilityElements` of the `HighlightedCard`

## 🧪 **How can I verify this?**

https://github.com/Telefonica/mistica-ios/assets/43632903/170d5c58-cd11-456b-bbb9-a42f123dbb39


