### PR TITLE
fix(HighlightedCard): actionButton duplicated for accessibility tool

### DIFF
--- a/Sources/Mistica/Components/Cards/HighlightedCard.swift
+++ b/Sources/Mistica/Components/Cards/HighlightedCard.swift
@@ -143,7 +143,6 @@ public class HighlightedCard: UIView {
         get {
             [
                 horizontalStackView,
-                actionButton.isHidden ? nil : actionButton,
                 closeButton.isHidden ? nil : closeButton
             ].compactMap { $0 }
         }


### PR DESCRIPTION
## 🎟️ **Jira ticket**
[IOS-8932](https://jira.tid.es/browse/IOS-8932)

## 🥅 **What's the goal?**
QA team reported that the button "Try to ask aura something" that corresponds to the `actionButton` of the `HighlightedCard` is duplicated in their accessibility tool.

<img src="https://github.com/Telefonica/mistica-ios/assets/43632903/ad3a23e1-1b7d-4554-892c-eb1817ac33f0" width=25% height=25%>

## 🚧 **How do we do it?**
Remove it from the `accessibilityElements` because the button is accessible by default and now we do not have the `UIAccessibilityElement` for the card, removed in the [PR](https://github.com/Telefonica/mistica-ios/pull/275)

## 🧪 **How can I verify this?**
<img src="https://github.com/Telefonica/mistica-ios/assets/43632903/faaec062-8e9e-4b75-838b-46ed854fb163" width=25% height=25%>


