### PR TITLE
IOS-9013 Combine mistica into a single package to prevent duplicated symbols when importing Mistica and MisticaSwiftUI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ XCRESULT_FILE_PATH := $(TEST_OUTPUT_PATH)/$(SCHEMA).xcresult
 
 # Export config
 SCHEMA := MisticaCatalog
-TEST_SCHEMA := Mistica-Package
+TEST_SCHEMA := Mistica
 PROJECT_PATH := MisticaCatalog/MisticaCatalog.xcodeproj
 BUILD_PATH := $(ROOT_DIR)/build
 EXPORTED_OPTIONS_PATH := $(ROOT_DIR)/enterprise.plist

--- a/MisticaCatalog/MisticaCatalog.xcodeproj/project.pbxproj
+++ b/MisticaCatalog/MisticaCatalog.xcodeproj/project.pbxproj
@@ -9,7 +9,6 @@
 /* Begin PBXBuildFile section */
 		1822CA1A29E821D400980D47 /* HeaderCatalogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1822CA1929E821D400980D47 /* HeaderCatalogView.swift */; };
 		1860058F28A136CE009C3778 /* ColorsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1860058E28A136CE009C3778 /* ColorsView.swift */; };
-		1882EF41286EFF5F00F959FA /* MisticaSwiftUI in Frameworks */ = {isa = PBXBuildFile; productRef = 1882EF40286EFF5F00F959FA /* MisticaSwiftUI */; };
 		18E17AED287FFFBF0051E505 /* CatalogRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18E17AEC287FFFBF0051E505 /* CatalogRow.swift */; };
 		18E17AEF288007340051E505 /* Framework.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18E17AEE288007340051E505 /* Framework.swift */; };
 		18E3452C289D46C5005E6D81 /* FontsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18E3452B289D46C5005E6D81 /* FontsView.swift */; };
@@ -153,7 +152,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				B8EE89F22614B57600F79386 /* AppCenterDistribute in Frameworks */,
-				1882EF41286EFF5F00F959FA /* MisticaSwiftUI in Frameworks */,
 				B8F990632546CAA500DFBFE9 /* Mistica in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -369,7 +367,6 @@
 			packageProductDependencies = (
 				B8F990622546CAA500DFBFE9 /* Mistica */,
 				B8EE89F12614B57600F79386 /* AppCenterDistribute */,
-				1882EF40286EFF5F00F959FA /* MisticaSwiftUI */,
 			);
 			productName = MisticaCatalog;
 			productReference = B8F98FEA2546C95600DFBFE9 /* MisticaCatalog.app */;
@@ -713,10 +710,6 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		1882EF40286EFF5F00F959FA /* MisticaSwiftUI */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = MisticaSwiftUI;
-		};
 		18E42D47287F181700BB7B39 /* Mistica */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = Mistica;

--- a/Package.swift
+++ b/Package.swift
@@ -10,11 +10,7 @@ let package = Package(
     products: [
         .library(
             name: "Mistica",
-            targets: ["Mistica", "MisticaCommon"]
-        ),
-        .library(
-            name: "MisticaSwiftUI",
-            targets: ["MisticaSwiftUI", "MisticaCommon"]
+            targets: ["Mistica", "MisticaCommon", "MisticaSwiftUI"]
         )
     ],
     dependencies: [


### PR DESCRIPTION
## 🎟️ **Jira ticket**
IOS-9013

## 🥅 **What's the goal?**
As explained in the document https://confluence.tid.es/display/CTO/%5BAPPS%5D+Shared+Spec%3A+Mistica+iOS+issues+with+duplicated+symbols, the current `Package.swift` creates two libraries `Mistica` and `MisticaSwiftUI` with the same `MisticaCommon` code added to each library. This causes duplicated symbols and unexpected behaviour when importing the two libraries in the same target.

## 🚧 **How do we do it?**
Combine all Modules into a single `Mistica` library.

## 🧪 **How can I verify this?**
Run and build a project that uses Mistica and MisticaSwiftUI (E.g. MisticaCatalog), check that there are no longer duplicated symbols.