### PR TITLE
fix(Bottom Sheet): Fix component to expand horizontally

### DIFF
--- a/Sources/Mistica/Components/Sheet/View/Fragments/List/Rows/InformativeRow.swift
+++ b/Sources/Mistica/Components/Sheet/View/Fragments/List/Rows/InformativeRow.swift
@@ -53,7 +53,7 @@ class InformativeRow: UIView {
 
     private let bottomContent: UIStackView = {
         let stackView = UIStackView()
-        stackView.spacing = 8
+        stackView.isLayoutMarginsRelativeArrangement = true
         return stackView
     }()
 
@@ -65,8 +65,6 @@ class InformativeRow: UIView {
         label.minHeight = 20
         return label
     }()
-
-    private lazy var dummyView = SpacerView(axis: .horizontal, amount: 1)
 }
 
 // MARK: Private
@@ -84,13 +82,12 @@ private extension InformativeRow {
             bottomContent.isHidden = true
         }
 
-        dummyView.amount = item.icon.size.width
+        bottomContent.layoutMargins.left = item.icon.size.width + 8
     }
 
     func layoutViews() {
         addSubview(withDefaultConstraints: centerSection)
 
-        bottomContent.addArrangedSubview(dummyView)
         bottomContent.addArrangedSubview(detailLabel)
 
         centerSection.addArrangedSubview(topContent)
@@ -109,7 +106,7 @@ private class TopContentView: UIView {
     private var frontStackView: UIStackView = {
         let stackView = UIStackView()
         stackView.alignment = .center
-        stackView.spacing = 8
+        stackView.isLayoutMarginsRelativeArrangement = true
         return stackView
     }()
 
@@ -137,8 +134,6 @@ private class TopContentView: UIView {
         return label
     }()
 
-    private lazy var dummyView = SpacerView(axis: .horizontal, amount: 1)
-
     var title: String? {
         didSet {
             dummyTitleLabel.text = title
@@ -150,7 +145,7 @@ private class TopContentView: UIView {
         didSet {
             iconImageView.intrinsicHeight = icon.size.height
             iconImageView.intrinsicWidth = icon.size.width
-            dummyView.amount = icon.size.width
+            frontStackView.layoutMargins.left = icon.size.width + 8
 
             load(icon: icon, in: iconImageView)
 
@@ -179,7 +174,6 @@ private class TopContentView: UIView {
         backStackView.addArrangedSubview(iconImageView)
         backStackView.addArrangedSubview(dummyTitleLabel)
 
-        frontStackView.addArrangedSubview(dummyView)
         frontStackView.addArrangedSubview(titleLabel)
     }
 

--- a/Sources/Mistica/Components/Sheet/View/Fragments/List/Rows/InformativeRow.swift
+++ b/Sources/Mistica/Components/Sheet/View/Fragments/List/Rows/InformativeRow.swift
@@ -10,6 +10,10 @@ import UIKit
 
 // MARK: InformativeRow
 
+private enum Constants: CGFloat {
+    case extraLeftMargin = 8
+}
+
 class InformativeRow: UIView {
     struct Asset {
         let url: String
@@ -82,7 +86,7 @@ private extension InformativeRow {
             bottomContent.isHidden = true
         }
 
-        bottomContent.layoutMargins.left = item.icon.size.width + 8
+        bottomContent.layoutMargins.left = item.icon.size.width + Constants.extraLeftMargin.rawValue
     }
 
     func layoutViews() {
@@ -145,7 +149,7 @@ private class TopContentView: UIView {
         didSet {
             iconImageView.intrinsicHeight = icon.size.height
             iconImageView.intrinsicWidth = icon.size.width
-            frontStackView.layoutMargins.left = icon.size.width + 8
+            frontStackView.layoutMargins.left = icon.size.width + Constants.extraLeftMargin.rawValue
 
             load(icon: icon, in: iconImageView)
 


### PR DESCRIPTION
## 🎟️ **Jira ticket**
[IOS-9113](https://jira.tid.es/browse/IOS-9113)

## 🥅 **What's the goal?**
- Fix the component to fit in iOS 14.5 or less. The texts are not well shown

## 🚧 **How do we do it?**
Info: The dot is centered on a single line label with the same specs than the visible label, but is in a deeper layer stackView.
- The component was using a dummy view to create the space for the dot in the front stackView. This dummy view has been removed and the stackView modifies the layout margin to replace this space.

## 🧪 **How can I verify this?**
![Simulator Screenshot - iPhone 6s - 2023-07-17 at 12 13 34](https://github.com/Telefonica/mistica-ios/assets/139126842/a02be5ac-b306-4f83-a3a6-bd7556673626)
![Simulator Screenshot - iPhone 6s - 2023-07-17 at 12 14 51](https://github.com/Telefonica/mistica-ios/assets/139126842/b706e09e-35b4-4c54-b500-9932b431449c)
![Simulator Screenshot - iPhone 6s - 2023-07-17 at 12 14 56](https://github.com/Telefonica/mistica-ios/assets/139126842/32fb6d83-da1f-4705-9009-d8dcbb2f0b27)
