### PR TITLE
[IOS-9461] Fix URL(string:) behavior

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.7
+// swift-tools-version:5.9
 
 import PackageDescription
 

--- a/Sources/Mistica/Components/Sheet/View/Fragments/List/Rows/ActionRow.swift
+++ b/Sources/Mistica/Components/Sheet/View/Fragments/List/Rows/ActionRow.swift
@@ -76,9 +76,9 @@ private extension ActionRow {
     }
 
     func load(url: String, urlDark: String?, in imageView: UIImageView) {
-        guard let url = URL(string: url) else { return }
+        guard let url = URL(urlString: url) else { return }
         if let urlDark = urlDark,
-           let urlForDarkMode = URL(string: urlDark) {
+           let urlForDarkMode = URL(urlString: urlDark) {
             imageView.load(url: url, urlForDarkMode: urlForDarkMode, renderAsTemplate: true)
         } else {
             imageView.load(url: url, renderAsTemplate: true)

--- a/Sources/Mistica/Components/Sheet/View/Fragments/List/Rows/InformativeRow.swift
+++ b/Sources/Mistica/Components/Sheet/View/Fragments/List/Rows/InformativeRow.swift
@@ -187,9 +187,9 @@ private class TopContentView: UIView {
             imageView.image = .bullet.withRenderingMode(.alwaysTemplate)
         case .small(let url, let urlDark),
              .regular(let url, let urlDark):
-            guard let url = URL(string: url) else { return }
+            guard let url = URL(urlString: url) else { return }
             if let urlDark = urlDark,
-               let urlForDarkMode = URL(string: urlDark) {
+               let urlForDarkMode = URL(urlString: urlDark) {
                 imageView.load(url: url, urlForDarkMode: urlForDarkMode, renderAsTemplate: true)
             } else {
                 imageView.load(url: url, renderAsTemplate: true)

--- a/Sources/Mistica/Components/Sheet/View/Fragments/List/Rows/SingleSelectionRow.swift
+++ b/Sources/Mistica/Components/Sheet/View/Fragments/List/Rows/SingleSelectionRow.swift
@@ -111,9 +111,9 @@ private extension SingleSelectionRowView {
     }
 
     func load(icon: SingleSelectionItemIcon, in imageView: UIImageView) {
-        guard let url = URL(string: icon.url) else { return }
+        guard let url = URL(urlString: icon.url) else { return }
         if let urlDark = icon.urlDark,
-           let urlForDarkMode = URL(string: urlDark) {
+           let urlForDarkMode = URL(urlString: urlDark) {
             imageView.load(url: url, urlForDarkMode: urlForDarkMode)
         } else {
             imageView.load(url: url)

--- a/Sources/Mistica/Utils/Extensions/URL+Utils.swift
+++ b/Sources/Mistica/Utils/Extensions/URL+Utils.swift
@@ -1,8 +1,9 @@
 //
 //  URL+Utils.swift
-//  MisticaCatalog
 //
-//  Created by Alejandro Ruiz on 27/10/23.
+//  Made with ❤️ by Novum
+//
+//  Copyright © Telefonica. All rights reserved.
 //
 
 import Foundation
@@ -10,10 +11,10 @@ import Foundation
 public extension URL {
     /**
      Apple’s URL parsing implemented RFC1738/1808 standard and was changed to RFC3986 starting from iOS 17.
-     
+
      Actually, it can produce problems with code written before, because now URL(urlString: "Invalid URL") is not nil. Apple updated the URL initializer for iOS 17 with a new Bool parameter     encodingInvalidCharacters that has a default value (true) — it is what makes the behavior unpredictable. This initializer can revert the old behavior and add false directly enconding invalid characters.
      */
-    
+
     init?(urlString: String) {
         if #available(iOS 17.0, *) {
             self.init(string: urlString, encodingInvalidCharacters: false)

--- a/Sources/Mistica/Utils/Extensions/URL+Utils.swift
+++ b/Sources/Mistica/Utils/Extensions/URL+Utils.swift
@@ -1,0 +1,24 @@
+//
+//  URL+Utils.swift
+//  MisticaCatalog
+//
+//  Created by Alejandro Ruiz on 27/10/23.
+//
+
+import Foundation
+
+public extension URL {
+    /**
+     Apple’s URL parsing implemented RFC1738/1808 standard and was changed to RFC3986 starting from iOS 17.
+     
+     Actually, it can produce problems with code written before, because now URL(urlString: "Invalid URL") is not nil. Apple updated the URL initializer for iOS 17 with a new Bool parameter     encodingInvalidCharacters that has a default value (true) — it is what makes the behavior unpredictable. This initializer can revert the old behavior and add false directly enconding invalid characters.
+     */
+    
+    init?(urlString: String) {
+        if #available(iOS 17.0, *) {
+            self.init(string: urlString, encodingInvalidCharacters: false)
+        } else {
+            self.init(string: urlString)
+        }
+    }
+}


### PR DESCRIPTION
## 🎟️ **Jira ticket**
https://jira.tid.es/browse/IOS-9461

## 🥅 **What's the goal?**
Apple’s URL parsing implemented RFC1738/1808 standard and was changed to RFC3986 starting from iOS 17. Actually, it can produce problems with code written before, because now URL(string: "Invalid URL") is not nil. Apple updated the URL initializer for iOS 17 with a new Bool parameter encodingInvalidCharacters that has a default value (true) — it is what makes the behavior unpredictable and it needs to be handled.

## 🚧 **How do we do it?**
We have added a custom initializer where we will pass our urlString and behind if we are in iOS 17 we will set the new parameter encodingInvalidCharacters to false so that the behavior is similar to what we had before and return nil if the URL is not valid.

This custom initializer will be the one that by default we will have to use for new URLs that we want to validate and the one that replaces all the previous initializers that we already have implemented.
