### PR TITLE
IOS-9479 Fix URL extension to be internal instead of public to avoid …

### DIFF
--- a/Sources/Mistica/Utils/Extensions/URL+Utils.swift
+++ b/Sources/Mistica/Utils/Extensions/URL+Utils.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public extension URL {
+internal extension URL {
     /**
      Apple’s URL parsing implemented RFC1738/1808 standard and was changed to RFC3986 starting from iOS 17.
 


### PR DESCRIPTION
## 🎟️ **Jira ticket**
[IOS-9479](https://jira.tid.es/browse/IOS-9479) Make URL(urlString:) init method as internal to avoid collisions with other implementations.

## 🥅 **What's the goal?**
Avoid collisions with other implementations of this method and do not expose URL extensions from Mistica.

## 🚧 **How do we do it?**
I made the extension internal.

## 🧪 **How can I verify this?**

## 🏑 **AppCenter build**
