### PR TITLE
IOS-9445 Hide last divider

### DIFF
--- a/MisticaCatalog/Source/Catalog/CatalogList.swift
+++ b/MisticaCatalog/Source/Catalog/CatalogList.swift
@@ -32,7 +32,8 @@ struct CatalogList: View {
                             .navigationTitle(row.title)
                             .navigationBarTitleDisplayMode(.inline)
                     }
-                ).shouldShowDivider(row != rows.last)
+                )
+                .shouldShowDivider(row != rows.last)
             }
         }
         .misticaListStyle()

--- a/MisticaCatalog/Source/Catalog/CatalogList.swift
+++ b/MisticaCatalog/Source/Catalog/CatalogList.swift
@@ -19,17 +19,20 @@ struct CatalogList: View {
                 Cell(
                     style: .fullwidth,
                     title: row.title,
+                    subtitle: nil,
+                    description: nil,
                     assetType: .smallIcon(
                         Image(uiImage: row.icon),
                         foregroundColor: nil
                     ),
-                    presetView: { CellNavigationPreset() }
-                )
-                .navigationLink {
-                    componentView(for: row)
-                        .navigationTitle(row.title)
-                        .navigationBarTitleDisplayMode(.inline)
-                }
+                    presetView: { CellNavigationPreset() },
+                    headlineView: { },
+                    destinationView: {
+                        componentView(for: row)
+                            .navigationTitle(row.title)
+                            .navigationBarTitleDisplayMode(.inline)
+                    }
+                ).shouldShowDivider(row != rows.last)
             }
         }
         .misticaListStyle()

--- a/MisticaCatalog/Source/Catalog/CatalogList.swift
+++ b/MisticaCatalog/Source/Catalog/CatalogList.swift
@@ -26,7 +26,7 @@ struct CatalogList: View {
                         foregroundColor: nil
                     ),
                     presetView: { CellNavigationPreset() },
-                    headlineView: { },
+                    headlineView: {},
                     destinationView: {
                         componentView(for: row)
                             .navigationTitle(row.title)

--- a/MisticaCatalog/Source/Catalog/MisticaSwiftUI/Components/ListCatalogView.swift
+++ b/MisticaCatalog/Source/Catalog/MisticaSwiftUI/Components/ListCatalogView.swift
@@ -65,7 +65,8 @@ struct ListCatalogView: View {
 
             NavigationLink("Show List") {
                 List {
-                    ForEach(0 ..< 50) { _ in
+                    let range = 0 ..< 20
+                    ForEach(range, id: \.self) { count in
                         Cell(
                             style: styles[selectedStyleIndex],
                             title: title,
@@ -73,9 +74,10 @@ struct ListCatalogView: View {
                             description: description.isEmpty ? nil : description,
                             assetType: assetTypes[selectedAssetTypeIndex],
                             presetView: { presetView },
-                            headlineView: { headlineView }
+                            headlineView: { headlineView },
+                            destinationView: { Text("Detail view \(count)") }
                         )
-                        .navigationLink(to: { Text("Detail view") })
+                        .shouldShowDivider(count != range.last)
                     }
                 }
                 .misticaListStyle()

--- a/MisticaCatalog/Source/ColorsView.swift
+++ b/MisticaCatalog/Source/ColorsView.swift
@@ -24,6 +24,7 @@ struct ColorsView: View {
                     description: item.color.hexString.uppercased(),
                     assetType: .roundImage(circle(with: item.color))
                 )
+                .shouldShowDivider(item.name != colors.last?.name)
             }
         }
         .misticaListStyle()

--- a/Sources/MisticaSwiftUI/Components/List/Cell.swift
+++ b/Sources/MisticaSwiftUI/Components/List/Cell.swift
@@ -54,6 +54,7 @@ public struct Cell<PresetView: View, HeadlineView: View, Destination: View>: Vie
     private var backgroundColor = Color.backgroundContainer
     private var pressedBackgroundColor = Color.neutralLow.opacity(0.8)
     private var allowsPressing = true
+    private var shouldShowDivider = true
 
     @State var isPressed = false
 
@@ -90,7 +91,9 @@ public struct Cell<PresetView: View, HeadlineView: View, Destination: View>: Vie
 
         case .fullwidth:
             coreView
-                .overlay(divider, alignment: .bottom)
+                .if(shouldShowDivider) {
+                    $0.overlay(divider, alignment: .bottom)
+                }
                 .if(allowsPressing) {
                     $0.overlay(cellLink)
                 }
@@ -192,27 +195,6 @@ public struct Cell<PresetView: View, HeadlineView: View, Destination: View>: Vie
     @ViewBuilder
     private var cellLink: some View {
         CellLink(isPressed: $isPressed, destination: { destination })
-    }
-}
-
-// MARK: Utils
-
-public extension Cell {
-    /// Sets a NavigationLink as a background with no opacity. This behaves as a workaround to avoid
-    /// NavigationLinks to add extra views to the Cell inside List. Otherwise, the system will add the default chevron.
-    func navigationLink<T: View>(to destination: () -> T) -> Cell<PresetView, HeadlineView, T> {
-        var cell = Cell<PresetView, HeadlineView, T>(
-            style: style,
-            title: title,
-            subtitle: subtitle,
-            description: description,
-            assetType: assetType,
-            presetView: { presetView },
-            headlineView: { headlineView },
-            destinationView: destination
-        )
-        cell.allowsPressing = true
-        return cell
     }
 }
 
@@ -394,11 +376,17 @@ public extension Cell {
         cell.allowsPressing = allowsPressing
         return cell
     }
+    
+    func shouldShowDivider(_ shouldShowDivider: Bool) -> Cell {
+        var cell = self
+        cell.shouldShowDivider = shouldShowDivider
+        return cell
+    }
 }
 
 // MARK: Helpers
 
-struct ListSeparatorHiddenModifieriOS15: ViewModifier {
+struct ListSeparatorHiddenModifier: ViewModifier {
     public func body(content: Content) -> some View {
         if #available(iOS 15.0, *) {
             content
@@ -418,27 +406,9 @@ struct ListSeparatorHiddenModifieriOS15: ViewModifier {
     }
 }
 
-struct ListSeparatorHiddenModifier: ViewModifier {
-    public func body(content: Content) -> some View {
-        content
-            .listRowInsets(EdgeInsets())
-            .overlay(
-                VStack {
-                    Divider(color: .background)
-                    Spacer()
-                    Divider(color: .background)
-                }
-            )
-    }
-}
-
 public extension View {
     func listSeparatorHidden() -> some View {
-        conditionalModifier(
-            .iOS15,
-            then: { $0.modifier(ListSeparatorHiddenModifieriOS15()) },
-            else: { $0.modifier(ListSeparatorHiddenModifier()) }
-        )
+        modifier(ListSeparatorHiddenModifier())
     }
 }
 

--- a/Sources/MisticaSwiftUI/Components/List/Cell.swift
+++ b/Sources/MisticaSwiftUI/Components/List/Cell.swift
@@ -376,7 +376,7 @@ public extension Cell {
         cell.allowsPressing = allowsPressing
         return cell
     }
-    
+
     func shouldShowDivider(_ shouldShowDivider: Bool) -> Cell {
         var cell = self
         cell.shouldShowDivider = shouldShowDivider

--- a/Sources/MisticaSwiftUI/Components/List/README.md
+++ b/Sources/MisticaSwiftUI/Components/List/README.md
@@ -43,6 +43,17 @@ NavigationView {
 }
 ```
 
+The last cell on a Mistica List should not have a divider. Use the modifier (`shouldShowDivider(<condition to match last item>)`) to hide it. E.g.:
+
+```swift
+    ForEach(rows) { row in
+        Cell(
+            ...
+        )
+        .shouldShowDivider(row != rows.last)
+    }
+```
+
 #### Control Customization
 
 `Cell` can be configured with a custom control like a `Toggle`.


### PR DESCRIPTION
## 🎟️ **Jira ticket**
IOS-9445

## 🥅 **What's the goal?**
Hide last divider in mistica lists

## 🚧 **How do we do it?**
- Add a modifier to hide the cell divider
- Update usages
- Update documentation

## 🧪 **How can I verify this?**
Before:

https://github.com/Telefonica/mistica-ios/assets/2429905/62fcd302-31c0-4a39-8ddd-05522587c822


After:

https://github.com/Telefonica/mistica-ios/assets/2429905/99220923-3fa1-4aeb-8583-65c3a2e9b226


