### PR TITLE
fix(TabsView): Allows consumers to select an item and deselect all

### DIFF
--- a/Sources/Mistica/Components/Tabs/TabsView.swift
+++ b/Sources/Mistica/Components/Tabs/TabsView.swift
@@ -105,7 +105,7 @@ public extension TabsView {
             self.selectTabItem(at: max(0, index - 1))
         }
     }
-    
+
     func selectTabItem(at row: Int) {
         let indexPath = IndexPath(item: row, section: 0)
         firstIndexPathForSelectedItem = indexPath
@@ -119,9 +119,9 @@ public extension TabsView {
         let tabItem = tabsItems[row]
         delegate?.tabsView(self, didSelectTab: tabItem)
     }
-    
+
     func deselectAll() {
-        for indexPath in (collectionView.indexPathsForSelectedItems ?? []) {
+        for indexPath in collectionView.indexPathsForSelectedItems ?? [] {
             deselectTabItem(at: indexPath.row)
         }
     }

--- a/Sources/Mistica/Components/Tabs/TabsView.swift
+++ b/Sources/Mistica/Components/Tabs/TabsView.swift
@@ -107,6 +107,7 @@ public extension TabsView {
     }
 
     func selectTabItem(at row: Int) {
+        deselect()
         let indexPath = IndexPath(item: row, section: 0)
         firstIndexPathForSelectedItem = indexPath
 
@@ -118,12 +119,6 @@ public extension TabsView {
 
         let tabItem = tabsItems[row]
         delegate?.tabsView(self, didSelectTab: tabItem)
-    }
-
-    func deselectAll() {
-        for indexPath in collectionView.indexPathsForSelectedItems ?? [] {
-            deselectTabItem(at: indexPath.row)
-        }
     }
 }
 
@@ -160,7 +155,13 @@ private extension TabsView {
             heightAnchor.constraint(equalToConstant: Constants.componentHeight)
         ])
     }
-
+    
+    func deselect() {
+        for indexPath in collectionView.indexPathsForSelectedItems ?? [] {
+            deselectTabItem(at: indexPath.row)
+        }
+    }
+    
     func deselectTabItem(at row: Int) {
         let indexPath = IndexPath(item: row, section: 0)
         if let tabItemView = collectionView.cellForItem(at: indexPath) as? TabItemViewCell {

--- a/Sources/Mistica/Components/Tabs/TabsView.swift
+++ b/Sources/Mistica/Components/Tabs/TabsView.swift
@@ -155,13 +155,13 @@ private extension TabsView {
             heightAnchor.constraint(equalToConstant: Constants.componentHeight)
         ])
     }
-    
+
     func deselect() {
         for indexPath in collectionView.indexPathsForSelectedItems ?? [] {
             deselectTabItem(at: indexPath.row)
         }
     }
-    
+
     func deselectTabItem(at row: Int) {
         let indexPath = IndexPath(item: row, section: 0)
         if let tabItemView = collectionView.cellForItem(at: indexPath) as? TabItemViewCell {

--- a/Sources/Mistica/Components/Tabs/TabsView.swift
+++ b/Sources/Mistica/Components/Tabs/TabsView.swift
@@ -105,6 +105,26 @@ public extension TabsView {
             self.selectTabItem(at: max(0, index - 1))
         }
     }
+    
+    func selectTabItem(at row: Int) {
+        let indexPath = IndexPath(item: row, section: 0)
+        firstIndexPathForSelectedItem = indexPath
+
+        if let tabItemView = collectionView.cellForItem(at: indexPath) as? TabItemViewCell {
+            tabItemView.showSelected()
+        }
+
+        collectionView.selectItem(at: indexPath, animated: true, scrollPosition: .centeredHorizontally)
+
+        let tabItem = tabsItems[row]
+        delegate?.tabsView(self, didSelectTab: tabItem)
+    }
+    
+    func deselectAll() {
+        for indexPath in (collectionView.indexPathsForSelectedItems ?? []) {
+            deselectTabItem(at: indexPath.row)
+        }
+    }
 }
 
 // MARK: - Private
@@ -139,20 +159,6 @@ private extension TabsView {
             collectionView.heightAnchor.constraint(equalToConstant: Constants.componentHeight),
             heightAnchor.constraint(equalToConstant: Constants.componentHeight)
         ])
-    }
-
-    func selectTabItem(at row: Int) {
-        let indexPath = IndexPath(item: row, section: 0)
-        firstIndexPathForSelectedItem = indexPath
-
-        if let tabItemView = collectionView.cellForItem(at: indexPath) as? TabItemViewCell {
-            tabItemView.showSelected()
-        }
-
-        collectionView.selectItem(at: indexPath, animated: true, scrollPosition: .centeredHorizontally)
-
-        let tabItem = tabsItems[row]
-        delegate?.tabsView(self, didSelectTab: tabItem)
     }
 
     func deselectTabItem(at row: Int) {


### PR DESCRIPTION
## 🎟️ **Jira ticket**

https://jira.tid.es/browse/SMARTWIFI-8301

## 🥅 **What's the goal?**

Allow users of TabsView component to select a tabItem when needed.

This is needed in SmartWiFi to allow tabItem selection on controller swipe when used in complement with a UIPageController.

See following video:

https://github.com/Telefonica/mistica-ios/assets/23734068/5bb22d7f-6676-4fb8-802b-895511330a7d

## 🚧 **How do we do it?**
- Add `deselectAll` method as we need to previously deselect all items before selecting the target controller on swipe (this prevents cumulating indicators in tabs)
- Make `selectTabItem(at:)` public so we can use it from outside.

## 🧪 **How can I verify this?**

See previously attached video.
