### PR TITLE
IOS-9672 Add missing templates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,11 +42,11 @@ endif
 
 # TokenGenerator func to be used in all token generators.
 define tokenGenerator
-	@echo "Generating Mistica $(2) palettes"
+	@echo "Generating Mistica $(2) interfaces"
 	hygen $(1) Mistica$(2) --json $(MISTICA_DESIGN_PATH)$(MISTICA_DESIGN_TOKENS_PATH)/$(Movistar).json
 
-	# Generates N corner radius palettes for every brand passed in BRAND_FILES
 	for key in $(BRAND_FILES) ; do \
+		echo "Generating $$key $(2) palette"; \
 		hygen $(1) Brand$(2) --name $$key --json $(MISTICA_DESIGN_PATH)$(MISTICA_DESIGN_TOKENS_PATH)/$$key.json ; \
 	done
 endef

--- a/_templates/ColorTokenGenerator/MisticaColors/ToolkitColorsAction.ejs.t
+++ b/_templates/ColorTokenGenerator/MisticaColors/ToolkitColorsAction.ejs.t
@@ -1,0 +1,32 @@
+---
+to: Sources/MisticaCommon/Colors/ColorToolkit+Color.swift
+force: true
+---
+<%#
+to: The path where the file will be create
+force: If the file can be overwritten or not
+-%>
+
+<%_
+let jsonObject = h.params(json)
+-%>
+
+// Generated using Make
+// DO NOT EDIT
+
+import SwiftUI
+
+public extension Color {
+<% Object.keys(jsonObject.jsonData.light).forEach(function(key) { -%>
+
+    static var <%= key %>: Color {
+        MisticaConfig.currentColors.<%= key %>.color
+    }
+<% }); -%>
+}
+
+private extension UIColor {
+    var color: Color {
+        Color(self)
+    }
+}

--- a/_templates/ColorTokenGenerator/MisticaColors/UIToolkitColorsAction.ejs.t
+++ b/_templates/ColorTokenGenerator/MisticaColors/UIToolkitColorsAction.ejs.t
@@ -1,0 +1,36 @@
+---
+to: Sources/MisticaCommon/Colors/ColorToolkit+UIColor.swift
+force: true
+---
+<%#
+to: The path where the file will be create
+force: If the file can be overwritten or not
+-%>
+
+<%_
+let jsonObject = h.params(json)
+-%>
+
+// Generated using Make
+// DO NOT EDIT
+
+import UIKit
+
+public extension UIColor {
+<% Object.keys(jsonObject.jsonData.light).forEach(function(key) { -%>
+
+    @objc(<%= key %>Color)
+    static var <%= key %>: UIColor {
+        MisticaConfig.currentColors.<%= key %>
+    }
+<% }); -%>
+}
+
+public extension BrandStyle {
+    var preferredStatusBarStyle: UIStatusBarStyle {
+        switch self {
+        case .movistar, .vivo, .o2, .blau, .custom, .vivoNew, .telefonica:
+            return .lightContent
+        }
+    }
+}


### PR DESCRIPTION
## 🎟️ **Jira ticket**
https://jira.tid.es/browse/IOS-9672

## 🥅 **What's the goal?**
When `mistica-design` adds a new color, it's not accessible due to we use `ColorToolkit+UIColor` & `ColorToolkit+Color` helper extensions.
I've not updated the palettes since it would affect production [out of scope]. I think Yayo is on it (https://github.com/Telefonica/mistica-ios/pull/327) but I had to help him adding some missing static methods https://github.com/Telefonica/mistica-ios/pull/327/commits/c7f2a0294f0671761a09f73cbffc718fe30c18fa which will be solved with these templates

## 🚧 **How do we do it?**
Just added a couple of actions for Colors generator which generates those files.

## 🧪 **How can I verify this?**
`make skin ref=production`
- ✅  The process is success
- ✅  The app is built and works properly
