### PR TITLE
IOS-9726 Fix close button with any duration

### DIFF
--- a/MisticaCatalog/Source/Catalog/Mistica/Components/UICatalogCroutonViewController.swift
+++ b/MisticaCatalog/Source/Catalog/Mistica/Components/UICatalogCroutonViewController.swift
@@ -168,7 +168,7 @@ private extension UICatalogCroutonViewController {
             guard let action = actionTitleCell.textField.text, !action.isEmpty else {
                 return .infinite(nil)
             }
-            
+
             return .infinite(SnackbarAction(title: action, handler: {}))
         case .none:
             return .fiveSeconds

--- a/MisticaCatalog/Source/Catalog/Mistica/Components/UICatalogCroutonViewController.swift
+++ b/MisticaCatalog/Source/Catalog/Mistica/Components/UICatalogCroutonViewController.swift
@@ -118,15 +118,15 @@ extension UICatalogCroutonViewController {
         if indexPath.row == 2 {
             let config = SnackbarConfig(
                 title: titleCell.textField.text ?? "",
-                dismissInterval: croutonDismissInterval
+                dismissInterval: croutonDismissInterval,
+                forceDismiss: forceDismiss
             )
             CroutonController.shared.showCrouton(
                 config: config,
                 style: selectedCroutonStyle,
                 dismissHandler: { reason in
                     print("\(reason.rawValue)")
-                },
-                forceDismiss: forceDismiss
+                }
             )
         } else {
             let sampleTabBarViewController = SampleTabBarViewController()
@@ -166,14 +166,10 @@ private extension UICatalogCroutonViewController {
 
         case .infinite:
             guard let action = actionTitleCell.textField.text, !action.isEmpty else {
-                return .infiniteWithClose(nil)
+                return .infinite(nil)
             }
-
-            guard forceDismiss else {
-                return .infinite(SnackbarAction(title: action, handler: {}))
-            }
-
-            return .infiniteWithClose(SnackbarAction(title: action, handler: {}))
+            
+            return .infinite(SnackbarAction(title: action, handler: {}))
         case .none:
             return .fiveSeconds
         }

--- a/MisticaCatalog/Source/Catalog/MisticaSwiftUI/Components/SnackbarCatalogView.swift
+++ b/MisticaCatalog/Source/Catalog/MisticaSwiftUI/Components/SnackbarCatalogView.swift
@@ -105,7 +105,7 @@ struct SnackbarCatalogView: View {
             guard !buttonTitle.isEmpty else {
                 return .infinite(nil)
             }
-            
+
             return .infinite(SnackbarAction(title: buttonTitle, handler: {}))
         }
     }

--- a/MisticaCatalog/Source/Catalog/MisticaSwiftUI/Components/SnackbarCatalogView.swift
+++ b/MisticaCatalog/Source/Catalog/MisticaSwiftUI/Components/SnackbarCatalogView.swift
@@ -49,9 +49,7 @@ struct SnackbarCatalogView: View {
             section("Style") { stylePicker }
             section("Auto Dismiss Delay") { intervalPicker }
             section("Button Style") { buttonStylePicker }
-            if intervalStyles[selectedIntervalStyleIndex] == .infinite && !buttonTitle.isEmpty {
-                section("Force Dismiss") { Toggle("Has force dismiss action", isOn: $hasForceDismissAction) }
-            }
+            section("Force Dismiss") { Toggle("Has force dismiss action", isOn: $hasForceDismissAction) }
             section("Snackbar") {
                 Button("Show snackbar") {
                     withAnimation {
@@ -75,7 +73,8 @@ struct SnackbarCatalogView: View {
             buttonStyle: buttonStyles[selectedButtonStyleIndex],
             config: SnackbarConfig(
                 title: title,
-                dismissInterval: dismissInterval
+                dismissInterval: dismissInterval,
+                forceDismiss: hasForceDismissAction
             ),
             dismissHandlerBlock: { reason in
                 print(reason.rawValue)
@@ -87,7 +86,8 @@ struct SnackbarCatalogView: View {
             buttonStyle: buttonStyles[selectedButtonStyleIndex],
             config: SnackbarConfig(
                 title: title,
-                dismissInterval: dismissInterval
+                dismissInterval: dismissInterval,
+                forceDismiss: hasForceDismissAction
             ),
             dismissHandlerBlock: { reason in
                 print(reason.rawValue)
@@ -102,15 +102,11 @@ struct SnackbarCatalogView: View {
         case .tenSeconds:
             return .tenSeconds(SnackbarAction(title: buttonTitle.isEmpty ? "Action" : buttonTitle, handler: {}))
         case .infinite:
-            if !buttonTitle.isEmpty {
-                if hasForceDismissAction {
-                    return .infiniteWithClose(SnackbarAction(title: buttonTitle, handler: {}))
-                } else {
-                    return .infinite(SnackbarAction(title: buttonTitle, handler: {}))
-                }
-            } else {
-                return .infiniteWithClose(nil)
+            guard !buttonTitle.isEmpty else {
+                return .infinite(nil)
             }
+            
+            return .infinite(SnackbarAction(title: buttonTitle, handler: {}))
         }
     }
 
@@ -139,8 +135,6 @@ extension SnackbarCatalogView {
             return "10"
         case .infinite:
             return "∞"
-        case .infiniteWithClose:
-            return "∞ close"
         }
     }
 }

--- a/Sources/Mistica/Components/Crouton/Domain/CroutonConfig.swift
+++ b/Sources/Mistica/Components/Crouton/Domain/CroutonConfig.swift
@@ -40,7 +40,7 @@ public struct CroutonConfig {
 private extension Button.Style {
     private enum Constants {
         static let insets: UIEdgeInsets = .init(top: 5, left: 8, bottom: 5, right: 8)
-        static let minimumWidth: CGFloat = 44 
+        static let minimumWidth: CGFloat = 44
     }
 
     static var croutonInfoLink: Button.Style {

--- a/Sources/Mistica/Components/Crouton/Domain/CroutonConfig.swift
+++ b/Sources/Mistica/Components/Crouton/Domain/CroutonConfig.swift
@@ -40,7 +40,7 @@ public struct CroutonConfig {
 private extension Button.Style {
     private enum Constants {
         static let insets: UIEdgeInsets = .init(top: 5, left: 8, bottom: 5, right: 8)
-        static let minimumWidth: CGFloat = 44
+        static let minimumWidth: CGFloat = 44 
     }
 
     static var croutonInfoLink: Button.Style {

--- a/Sources/Mistica/Components/Crouton/Presentation/CroutonController.swift
+++ b/Sources/Mistica/Components/Crouton/Presentation/CroutonController.swift
@@ -38,15 +38,13 @@ public extension CroutonController {
     func showCrouton(
         config: SnackbarConfig,
         style: CroutonStyle = .info,
-        dismissHandler: DismissHandlerBlock? = nil,
-        forceDismiss: Bool = false
+        dismissHandler: DismissHandlerBlock? = nil
     ) -> Token {
         showCrouton(
             config: config,
             style: style,
             dismissHandler: dismissHandler,
-            rootViewController: UIApplication.shared.windows.filter(\.isKeyWindow).first?.rootViewController,
-            forceDismiss: forceDismiss
+            rootViewController: UIApplication.shared.windows.filter(\.isKeyWindow).first?.rootViewController
         )
     }
 
@@ -62,8 +60,7 @@ public extension CroutonController {
         config: SnackbarConfig,
         style: CroutonStyle = .info,
         dismissHandler: DismissHandlerBlock? = nil,
-        rootViewController: @escaping @autoclosure () -> UIViewController?,
-        forceDismiss: Bool = false
+        rootViewController: @escaping @autoclosure () -> UIViewController?
     ) -> Token {
         assertMainThread()
 
@@ -88,7 +85,7 @@ public extension CroutonController {
             action: overwrittenAction,
             config: styleConfig,
             dismissHandler: dismissHandler,
-            forceDismiss: forceDismiss
+            forceDismiss: config.forceDismiss
         )
 
         show(crouton, token: token, rootViewController: rootViewController)

--- a/Sources/Mistica/Components/Crouton/Presentation/CroutonView.swift
+++ b/Sources/Mistica/Components/Crouton/Presentation/CroutonView.swift
@@ -24,7 +24,7 @@ class CroutonView: UIView {
         static let margins = NSDirectionalEdgeInsets(top: 14, leading: 16, bottom: 14, trailing: 16)
         static let marginsWhenUsingSafeArea = NSDirectionalEdgeInsets(top: 14, leading: 16, bottom: 0, trailing: 16)
 
-        static let buttonWidthThresholdForVerticalLayout: CGFloat = 104
+        static let buttonWidthThresholdForVerticalLayout: CGFloat = 128
         static let horizontalSpacing: CGFloat = 16
         static let verticalSpacing: CGFloat = 18
 
@@ -234,12 +234,7 @@ extension CroutonView {
 
 private extension CroutonView {
     var shouldShowCloseButton: Bool {
-        switch config.overrideDismissInterval {
-        case .fiveSeconds, .tenSeconds(_), .infinite:
-            return false
-        case .infiniteWithClose:
-            return true
-        }
+        forceDismiss || (action == nil && config.overrideDismissInterval == .infinite(nil))
     }
 
     func layoutViews() {

--- a/Sources/MisticaCommon/Components/Snackbar/Domain/SnackbarConfig.swift
+++ b/Sources/MisticaCommon/Components/Snackbar/Domain/SnackbarConfig.swift
@@ -29,7 +29,7 @@ public enum SnackbarDismissInterval: Equatable {
             return 5
         case .tenSeconds:
             return 10
-        case .infinite(_):
+        case .infinite:
             return nil
         }
     }
@@ -49,16 +49,16 @@ public enum SnackbarDismissInterval: Equatable {
         switch self {
         case .fiveSeconds, .tenSeconds:
             return false
-        case .infinite(_):
+        case .infinite:
             return true
         }
     }
-    
-    public static func ==(lhs: SnackbarDismissInterval, rhs: SnackbarDismissInterval) -> Bool {
+
+    public static func == (lhs: SnackbarDismissInterval, rhs: SnackbarDismissInterval) -> Bool {
         switch (lhs, rhs) {
         case (.fiveSeconds, .fiveSeconds):
             return true
-        case (.tenSeconds(_),.tenSeconds(_)):
+        case (.tenSeconds(_), .tenSeconds(_)):
             return true
         case (.infinite(_), .infinite(_)):
             return true

--- a/Sources/MisticaCommon/Components/Snackbar/Domain/SnackbarConfig.swift
+++ b/Sources/MisticaCommon/Components/Snackbar/Domain/SnackbarConfig.swift
@@ -18,11 +18,10 @@ public struct SnackbarAction {
     }
 }
 
-public enum SnackbarDismissInterval {
+public enum SnackbarDismissInterval: Equatable {
     case fiveSeconds
     case tenSeconds(SnackbarAction)
-    case infinite(SnackbarAction)
-    case infiniteWithClose(SnackbarAction?)
+    case infinite(SnackbarAction?)
 
     public var timeInterval: TimeInterval? {
         switch self {
@@ -30,7 +29,7 @@ public enum SnackbarDismissInterval {
             return 5
         case .tenSeconds:
             return 10
-        case .infinite(_), .infiniteWithClose:
+        case .infinite(_):
             return nil
         }
     }
@@ -43,8 +42,6 @@ public enum SnackbarDismissInterval {
             return action
         case .infinite(let action):
             return action
-        case .infiniteWithClose(let action):
-            return action
         }
     }
 
@@ -52,8 +49,21 @@ public enum SnackbarDismissInterval {
         switch self {
         case .fiveSeconds, .tenSeconds:
             return false
-        case .infinite(_), .infiniteWithClose:
+        case .infinite(_):
             return true
+        }
+    }
+    
+    public static func ==(lhs: SnackbarDismissInterval, rhs: SnackbarDismissInterval) -> Bool {
+        switch (lhs, rhs) {
+        case (.fiveSeconds, .fiveSeconds):
+            return true
+        case (.tenSeconds(_),.tenSeconds(_)):
+            return true
+        case (.infinite(_), .infinite(_)):
+            return true
+        default:
+            return false
         }
     }
 }
@@ -61,9 +71,11 @@ public enum SnackbarDismissInterval {
 public struct SnackbarConfig {
     public let title: String
     public let dismissInterval: SnackbarDismissInterval
+    public let forceDismiss: Bool
 
-    public init(title: String, dismissInterval: SnackbarDismissInterval) {
+    public init(title: String, dismissInterval: SnackbarDismissInterval, forceDismiss: Bool = false) {
         self.title = title
         self.dismissInterval = dismissInterval
+        self.forceDismiss = forceDismiss
     }
 }

--- a/Sources/MisticaSwiftUI/Components/Snackbar/Snackbar.swift
+++ b/Sources/MisticaSwiftUI/Components/Snackbar/Snackbar.swift
@@ -176,12 +176,7 @@ private extension Snackbar {
     }
 
     var shouldShowCloseButton: Bool {
-        switch config.dismissInterval {
-        case .fiveSeconds, .tenSeconds(_), .infinite:
-            return false
-        case .infiniteWithClose:
-            return true
-        }
+        config.forceDismiss || (config.dismissInterval.action == nil && config.dismissInterval == .infinite(nil))
     }
 
     func executeDismissHandlerBlock(with reason: SnackbarDismissReason) {

--- a/Sources/MisticaSwiftUI/Components/Snackbar/View+Snackbar.swift
+++ b/Sources/MisticaSwiftUI/Components/Snackbar/View+Snackbar.swift
@@ -102,6 +102,7 @@ private struct SnackbarModifier: ViewModifier {
     var presentationMode: SnackbarPresentationMode = .normal
     var config: SnackbarConfig
     var dismissHandlerBlock: ((SnackbarDismissReason) -> Void)? = nil
+    var forceDismiss: Bool? = false
 
     func body(content: Content) -> some View {
         ZStack(alignment: .bottom) {

--- a/Tests/MisticaSwiftUITests/UI/CroutonTests.swift
+++ b/Tests/MisticaSwiftUITests/UI/CroutonTests.swift
@@ -120,7 +120,7 @@ final class CroutonTests: XCTestCase {
             .foregroundColor(.white)
             .crouton(
                 isVisible: .constant(true),
-                config: SnackbarConfig(title: "Title", dismissInterval: .infiniteWithClose(SnackbarAction(title: "Action", handler: {})))
+                config: SnackbarConfig(title: "Title", dismissInterval: .infinite(SnackbarAction(title: "Action", handler: {})), forceDismiss: true)
             )
         assertSnapshot(
             matching: UIHostingController(rootView: view),
@@ -134,7 +134,7 @@ final class CroutonTests: XCTestCase {
             .crouton(
                 isVisible: .constant(true),
                 buttonStyle: .large,
-                config: SnackbarConfig(title: "Title", dismissInterval: .infiniteWithClose(SnackbarAction(title: "Large Action", handler: {})))
+                config: SnackbarConfig(title: "Title", dismissInterval: .infinite(SnackbarAction(title: "Large Action", handler: {})), forceDismiss: true)
             )
         assertSnapshot(
             matching: UIHostingController(rootView: view),

--- a/Tests/MisticaSwiftUITests/UI/SnackbarTests.swift
+++ b/Tests/MisticaSwiftUITests/UI/SnackbarTests.swift
@@ -120,7 +120,7 @@ final class SnackbarTests: XCTestCase {
             .foregroundColor(.white)
             .snackbar(
                 isVisible: .constant(true),
-                config: SnackbarConfig(title: "Title", dismissInterval: .infiniteWithClose(SnackbarAction(title: "Action", handler: {})))
+                config: SnackbarConfig(title: "Title", dismissInterval: .infinite(SnackbarAction(title: "Action", handler: {})), forceDismiss: true)
             )
         assertSnapshot(
             matching: UIHostingController(rootView: view),
@@ -134,7 +134,7 @@ final class SnackbarTests: XCTestCase {
             .snackbar(
                 isVisible: .constant(true),
                 buttonStyle: .large,
-                config: SnackbarConfig(title: "Title", dismissInterval: .infiniteWithClose(SnackbarAction(title: "Large Action", handler: {})))
+                config: SnackbarConfig(title: "Title", dismissInterval: .infinite(SnackbarAction(title: "Large Action", handler: {})), forceDismiss: true)
             )
         assertSnapshot(
             matching: UIHostingController(rootView: view),


### PR DESCRIPTION
## 🎟️ **Jira ticket**
[IOS-9726](https://jira.tid.es/browse/IOS-9726) Fix a bug where the close button can only be configured with infinite duration

## 🥅 **What's the goal?**
The crouton/scnakbar should be able to show the close button with any duration configured.

## 🚧 **How do we do it?**
Remove the infiniteWithClose interval option and pass a flag which defines if the close button should be forced or not( if the duration is infinite and has no action defined, the close button will also be presented).

## 🧪 **How can I verify this?**
You can test it in the catalog.

## 🏑 **AppCenter build**
