### PR TITLE
fix(AccessibilityIdentifiers): IOS-9694 - New struct for common Ids

### DIFF
--- a/Sources/Mistica/Components/Lists/ControlPresets/NavigationPresetView.swift
+++ b/Sources/Mistica/Components/Lists/ControlPresets/NavigationPresetView.swift
@@ -33,15 +33,6 @@ public class NavigationPresetView: UIStackView {
         }
     }
 
-    public var setAccessibilityIdentifier: String? {
-        get {
-            accessibilityIdentifier
-        }
-        set {
-            accessibilityIdentifier = newValue
-        }
-    }
-
     override public var tintColor: UIColor! {
         get {
             super.tintColor
@@ -76,8 +67,13 @@ private extension NavigationPresetView {
         spacing = 16
 
         imageView.tintColor = .textSecondary
-        isAccessibilityElement = true
+        configureAccessibility()
 
         addArrangedSubview(imageView)
+    }
+
+    func configureAccessibility() {
+        isAccessibilityElement = true
+        accessibilityIdentifier = ListAccessibilityIdentifiers.chevron.rawValue
     }
 }

--- a/Sources/MisticaCommon/DefaultAccessibilityIdentifiers/DefaultAccessibilityIdentifiers.swift
+++ b/Sources/MisticaCommon/DefaultAccessibilityIdentifiers/DefaultAccessibilityIdentifiers.swift
@@ -1,0 +1,71 @@
+//
+//  DefaultAccessibilityIdentifiers.swift
+//
+//  Made with ❤️ by Novum
+//
+//  Copyright © Telefonica. All rights reserved.
+//
+
+import Foundation
+
+public struct DefaultAccessibilityIdentifier {
+    public struct Feature {
+        let description: String
+        public init(_ description: String) {
+            self.description = description
+        }
+    }
+
+    public struct Section {
+        let description: String
+        public init(_ description: String) {
+            self.description = description
+        }
+    }
+
+    public struct ElementType {
+        let description: String
+        public init(_ description: String) {
+            self.description = description
+        }
+    }
+
+    let feature: String
+    let section: String
+    let elementType: String
+
+    public init(
+        feature: DefaultAccessibilityIdentifier.Feature,
+        section: DefaultAccessibilityIdentifier.Section,
+        elementType: DefaultAccessibilityIdentifier.ElementType
+    ) {
+        self.feature = feature.description
+        self.section = section.description
+        self.elementType = elementType.description
+    }
+
+    public var rawValue: String {
+        [feature, section, elementType]
+            .compactMap { $0 }
+            .joined(separator: "_")
+    }
+}
+
+public extension DefaultAccessibilityIdentifier.Section {
+    static let item = DefaultAccessibilityIdentifier.Section("item")
+}
+
+public extension DefaultAccessibilityIdentifier.ElementType {
+    static let chevron = DefaultAccessibilityIdentifier.ElementType("chevron")
+    static let icon = DefaultAccessibilityIdentifier.ElementType("icon")
+    static let title = DefaultAccessibilityIdentifier.ElementType("title")
+    static let subtitle = DefaultAccessibilityIdentifier.ElementType("subtitle")
+    static let errorLabel = DefaultAccessibilityIdentifier.ElementType("error_reference")
+    static let primaryButton = DefaultAccessibilityIdentifier.ElementType("primary_button")
+    static let secondaryButton = DefaultAccessibilityIdentifier.ElementType("secondary_button")
+    static let linkButton = DefaultAccessibilityIdentifier.ElementType("link_button")
+    static let slot = DefaultAccessibilityIdentifier.ElementType("slot")
+    static let description = DefaultAccessibilityIdentifier.ElementType("description")
+    static let tag = DefaultAccessibilityIdentifier.ElementType("tag")
+    static let action = DefaultAccessibilityIdentifier.ElementType("action")
+}

--- a/Sources/MisticaCommon/DefaultAccessibilityIdentifiers/FeedbackAccessibilityIdentifiers.swift
+++ b/Sources/MisticaCommon/DefaultAccessibilityIdentifiers/FeedbackAccessibilityIdentifiers.swift
@@ -1,0 +1,21 @@
+//
+//  FeedbackAccessibilityIdentifiers.swift
+//
+//  Made with ❤️ by Novum
+//
+//  Copyright © Telefonica. All rights reserved.
+//
+
+private extension DefaultAccessibilityIdentifier.Feature {
+    static let feedback = DefaultAccessibilityIdentifier.Feature("feedback")
+}
+
+public enum FeedbackAccessibilityIdentifiers {
+    public static var icon = DefaultAccessibilityIdentifier(feature: .feedback, section: .item, elementType: .icon)
+    public static var title = DefaultAccessibilityIdentifier(feature: .feedback, section: .item, elementType: .title)
+    public static var description = DefaultAccessibilityIdentifier(feature: .feedback, section: .item, elementType: .description)
+    public static var primaryButton = DefaultAccessibilityIdentifier(feature: .feedback, section: .item, elementType: .primaryButton)
+    public static var secondaryButton = DefaultAccessibilityIdentifier(feature: .feedback, section: .item, elementType: .secondaryButton)
+    public static var linkButton = DefaultAccessibilityIdentifier(feature: .feedback, section: .item, elementType: .linkButton)
+    public static var slot = DefaultAccessibilityIdentifier(feature: .feedback, section: .item, elementType: .slot)
+}

--- a/Sources/MisticaCommon/DefaultAccessibilityIdentifiers/ListAccessibilityIdentifiers.swift
+++ b/Sources/MisticaCommon/DefaultAccessibilityIdentifiers/ListAccessibilityIdentifiers.swift
@@ -1,0 +1,24 @@
+//
+//  ListAccessibilityIdentifiers.swift
+//
+//  Made with ❤️ by Novum
+//
+//  Copyright © Telefonica. All rights reserved.
+//
+
+import Foundation
+
+private extension DefaultAccessibilityIdentifier.Feature {
+    static let list = DefaultAccessibilityIdentifier.Feature("list")
+}
+
+public enum ListAccessibilityIdentifiers {
+    public static var icon = DefaultAccessibilityIdentifier(feature: .list, section: .item, elementType: .icon)
+    public static var tag = DefaultAccessibilityIdentifier(feature: .list, section: .item, elementType: .tag)
+    public static var title = DefaultAccessibilityIdentifier(feature: .list, section: .item, elementType: .title)
+    public static var subtitle = DefaultAccessibilityIdentifier(feature: .list, section: .item, elementType: .subtitle)
+    public static var description = DefaultAccessibilityIdentifier(feature: .list, section: .item, elementType: .description)
+    public static var slot = DefaultAccessibilityIdentifier(feature: .list, section: .item, elementType: .slot)
+    public static var action = DefaultAccessibilityIdentifier(feature: .list, section: .item, elementType: .action)
+    public static var chevron = DefaultAccessibilityIdentifier(feature: .list, section: .item, elementType: .chevron)
+}

--- a/Sources/MisticaSwiftUI/Components/List/CellNavigationPreset.swift
+++ b/Sources/MisticaSwiftUI/Components/List/CellNavigationPreset.swift
@@ -31,6 +31,7 @@ public struct CellNavigationPreset: View {
                 .renderingMode(.template)
                 .foregroundColor(.neutralMedium)
                 .frame(width: Constants.smallImageSize, height: Constants.smallImageSize, alignment: .center)
+                .accessibilityIdentifier(ListAccessibilityIdentifiers.chevron.rawValue)
         }
     }
 }


### PR DESCRIPTION
## 🎟️ **Jira ticket**
[IOS-9694](https://jira.tid.es/browse/IOS-9694)

## 🥅 **What's the goal?**
Add a default ID for the list chevron image.

## 🚧 **How do we do it?**
We have brought from [iphoneapp](https://github.com/Telefonica/iphoneapp/blob/7b70716012437e1565e850314dc6d96e5320b8a2/Messenger/PlatformKit/Source/Testing/Accessibility/AccessibilityIdentifier.swift#L9) a struct called `DefaultAccessibilityIdentifier` where we have different properties to compose the identifier following the `Feature`, `Section` and `ElementType` defined as constants. This way we prepare mistica to unify the IDs with Android following the different ids configured in Figma, [like lists](https://www.figma.com/file/Be8QB9onmHunKCCAkIBAVr/branch/SY4mjjuquWijveRpvxvl0M/%F0%9F%94%B8-Lists-Specs?type=design&node-id=2811-5741&mode=design&t=g5taw3M4yCctMlm8-0)

To accomplish this issue we have created the enum `ListAccessibilityIdentifiers` which has different `DefaultAccessibilityIdentifier` constants, so we can use the chevron to set as default in the SwiftUI [CellNavigationPreset.swift](https://github.com/Telefonica/mistica-ios/compare/IOS-9694-ChevronAccesibilityCommonId?expand=1#diff-a282baae82dc9d78127f58ecab8bf40cad702887f7cce2ed167038f22d73f6bd) and UIKit version [/NavigationPresetView.swift](https://github.com/Telefonica/mistica-ios/compare/IOS-9694-ChevronAccesibilityCommonId?expand=1#diff-c4d7d9cd6b6076a5eb4126cd6aef5326533fbc0dc0162e85e86873cb21142cf7)  

⚾️ Extra Ball ⚾️

I created the [FeedbackAccessibilityIdentifiers.swift](https://github.com/Telefonica/mistica-ios/pull/334/files#diff-edb1f2764a1c7c7c85048d8109feeb31b958356605e761931b2f1eaea64fe8e3) to leave it prepared and check thath everything is well done

## 🧪 **How can I verify this?**

https://github.com/Telefonica/mistica-ios/assets/43632903/33de9c75-3f8e-4a6f-8aa9-d670a9c5f05b
