### PR TITLE
IOS-9663 Bottom sheet: Accessibility

### DIFF
--- a/MisticaCatalog/Source/Catalog/Mistica/Components/UICatalogSheetViewController.swift
+++ b/MisticaCatalog/Source/Catalog/Mistica/Components/UICatalogSheetViewController.swift
@@ -321,7 +321,8 @@ private extension UICatalogSheetViewController {
                 subtitle: sheetSubtitle,
                 description: sheetDescription
             ),
-            content: [content]
+            content: [content],
+            backgroundViewAccessibilityLabel: "Close"
         )
 
         return configuration
@@ -371,7 +372,8 @@ private extension UICatalogSheetViewController {
                 subtitle: sheetSubtitle,
                 description: sheetDescription
             ),
-            content: [content]
+            content: [content],
+            backgroundViewAccessibilityLabel: "Close"
         )
 
         return configuration
@@ -404,7 +406,8 @@ private extension UICatalogSheetViewController {
                 subtitle: sheetSubtitle,
                 description: sheetDescription
             ),
-            content: [content]
+            content: [content],
+            backgroundViewAccessibilityLabel: "Close"
         )
 
         return configuration
@@ -446,7 +449,8 @@ private extension UICatalogSheetViewController {
                 listType: .actions(items: actions),
                 autoSubmit: true,
                 selectedId: []
-            )]
+            )],
+            backgroundViewAccessibilityLabel: "Close"
         )
 
         return configuration

--- a/Sources/Mistica/Components/Sheet/Model/SheetConfiguration.swift
+++ b/Sources/Mistica/Components/Sheet/Model/SheetConfiguration.swift
@@ -12,13 +12,16 @@ import UIKit
 public struct SheetConfiguration {
     public let header: SheetHeader
     public let content: [SheetList]
+    public let backgroundViewAccessibilityLabel: String?
 
     public init(
         header: SheetHeader,
-        content: [SheetList]
+        content: [SheetList],
+        backgroundViewAccessibilityLabel: String? = nil
     ) {
         self.header = header
         self.content = content
+        self.backgroundViewAccessibilityLabel = backgroundViewAccessibilityLabel
     }
 }
 

--- a/Sources/Mistica/Components/Sheet/View/BottomSheetPresentation/BottomSheetPresentationController.swift
+++ b/Sources/Mistica/Components/Sheet/View/BottomSheetPresentation/BottomSheetPresentationController.swift
@@ -9,9 +9,24 @@
 import UIKit
 
 final class BottomSheetPresentationController: UIPresentationController {
+    private let backgroundViewAccessibilityLabel: String?
+
+    init(presentedViewController: UIViewController,
+         presenting presentingViewController: UIViewController?,
+         backgroundViewAccessibilityLabel: String?) {
+        self.backgroundViewAccessibilityLabel = backgroundViewAccessibilityLabel
+        super.init(presentedViewController: presentedViewController, presenting: presentingViewController)
+    }
+
     private lazy var backgroundDimmingView: DimmedView = {
         let view = DimmedView()
         view.didTap = { [weak self] _ in
+            self?.presentedViewController.dismiss(animated: true)
+        }
+
+        view.isAccessibilityElement = true
+        view.accessibilityLabel = backgroundViewAccessibilityLabel
+        view.accessibilityEscape = { [weak self] in
             self?.presentedViewController.dismiss(animated: true)
         }
         return view
@@ -91,6 +106,9 @@ final class BottomSheetPresentationController: UIPresentationController {
             ),
             bottomConstraint
         ])
+
+        // Sorting elements for VoiceOver
+        containerView.accessibilityElements = [presentedView, backgroundDimmingView]
 
         bottomSheetInteractiveDismissalTransition.bottomConstraint = bottomConstraint
         bottomSheetInteractiveDismissalTransition.heightConstraint = heightConstraint

--- a/Sources/Mistica/Components/Sheet/View/BottomSheetPresentation/BottomSheetTransitioningDelegate.swift
+++ b/Sources/Mistica/Components/Sheet/View/BottomSheetPresentation/BottomSheetTransitioningDelegate.swift
@@ -12,6 +12,11 @@ import UIKit
 
 final class BottomSheetTransitioningDelegate: NSObject, UIViewControllerTransitioningDelegate {
     private weak var bottomSheetPresentationController: BottomSheetPresentationController?
+    private let backgroundViewAccessibilityLabel: String?
+
+    init(backgroundViewAccessibilityLabel: String?) {
+        self.backgroundViewAccessibilityLabel = backgroundViewAccessibilityLabel
+    }
 
     func presentationController(
         forPresented presented: UIViewController,
@@ -20,7 +25,8 @@ final class BottomSheetTransitioningDelegate: NSObject, UIViewControllerTransiti
     ) -> UIPresentationController? {
         let bottomSheetPresentationController = BottomSheetPresentationController(
             presentedViewController: presented,
-            presenting: presenting ?? source
+            presenting: presenting ?? source,
+            backgroundViewAccessibilityLabel: backgroundViewAccessibilityLabel
         )
 
         self.bottomSheetPresentationController = bottomSheetPresentationController

--- a/Sources/Mistica/Components/Sheet/View/BottomSheetPresentation/DimmedView.swift
+++ b/Sources/Mistica/Components/Sheet/View/BottomSheetPresentation/DimmedView.swift
@@ -27,6 +27,8 @@ class DimmedView: UIView {
 
     /// The closure to be executed when a tap occurs
     var didTap: ((_ recognizer: UIGestureRecognizer) -> Void)?
+    /// The closure to be executed when a VoiceOver user performs a dismiss action
+    var accessibilityEscape: (() -> Void)?
 
     private lazy var tapGesture = UITapGestureRecognizer(target: self, action: #selector(didTapView))
 
@@ -48,5 +50,12 @@ class DimmedView: UIView {
 
     @objc private func didTapView() {
         didTap?(tapGesture)
+    }
+
+    override func accessibilityPerformEscape() -> Bool {
+        guard let accessibilityEscape else { return super.accessibilityPerformEscape() }
+
+        accessibilityEscape()
+        return true
     }
 }

--- a/Sources/Mistica/Components/Sheet/View/SheetViewController.swift
+++ b/Sources/Mistica/Components/Sheet/View/SheetViewController.swift
@@ -10,7 +10,7 @@ import Foundation
 import UIKit
 
 public class SheetViewController: UIViewController {
-    private lazy var bottomSheetTransitioningDelegate = BottomSheetTransitioningDelegate()
+    private lazy var bottomSheetTransitioningDelegate = BottomSheetTransitioningDelegate(backgroundViewAccessibilityLabel: config.backgroundViewAccessibilityLabel)
 
     override public var modalPresentationStyle: UIModalPresentationStyle {
         get {


### PR DESCRIPTION
## 🎟️ **Jira ticket**
https://jira.tid.es/browse/IOS-9663

## 🥅 **What's the goal?**
The bottom sheet component cannot be closed through Voice Over. 
This component allows closing with:
- drag down => not available with VoiceOver
- tap on the dimming view => not tappable with VoiceOver

## 🚧 **How do we do it?**
- dimming view is now tappable with Voice Over, setting the view as an accessibility element
- dimming view accessibility label can be configured, then the Voice Over will read that label
- "Z" gesture (standard gesture to close modals using Voice Over) has been added. More info: https://support.apple.com/es-es/guide/iphone/iph3e2e2281/ios#:~:text=Descartar%20un%20aviso%20o%20ir%20a%20la%20pantalla%20anterior

## 🧪 **How can I verify this?**

https://github.com/Telefonica/mistica-ios/assets/9945756/08a7b6f5-d199-492d-8c49-acca341cc4fe

