### PR TITLE
Improve destination param

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ OS_VERSION := 17.0
 DEVICE_NAME := iPhone 15
 SIMULATOR_NAME := $(DEVICE_NAME) ($(OS_VERSION))
 GET_INSTALLED_SIMULATOR_NAME := $(shell xcrun simctl list | grep -o "$(SIMULATOR_NAME)" | head -1)
+DESTINATION := platform=iOS Simulator,OS=$(OS_VERSION),name=$(DEVICE_NAME)
 
 # Paths
 ROOT_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
@@ -91,8 +92,8 @@ format:
 
 test: clean setup simulator
 	@echo "Testing with simulator $(SIMULATOR_NAME)"
-	$(XCODEBUILD) build-for-testing -scheme $(TEST_SCHEMA) -destination "platform=iOS Simulator,name=$(SIMULATOR_NAME)" | xcbeautify
-	$(XCODEBUILD) test-without-building -scheme $(TEST_SCHEMA) -resultBundlePath $(XCRESULT_FILE_PATH) -destination "platform=iOS Simulator,name=$(SIMULATOR_NAME)" | xcbeautify
+	$(XCODEBUILD) build-for-testing -scheme $(TEST_SCHEMA) -destination "$(DESTINATION)" | xcbeautify
+	$(XCODEBUILD) test-without-building -scheme $(TEST_SCHEMA) -resultBundlePath $(XCRESULT_FILE_PATH) -destination "$(DESTINATION)" | xcbeautify
 
 extract_tests_attachments:
 	@xcparse attachments $(XCRESULT_FILE_PATH) $(SCREENSHOT_DIFFS_OUTPUT_PATH) --uti public.plain-text public.image --test


### PR DESCRIPTION
## 🥅 **What's the goal?**
We found some issues executing tests due to the destination param looks working different due to the XC tools version.
See:
https://teams.microsoft.com/l/message/19:40b9dabcaf1a4abea1216117ac7c0596@thread.tacv2/1697557532308?tenantId=9744600e-3e04-492e-baa1-25ec245c6f10&groupId=992881f8-bbab-4891-8c17-ffe99ba6f43b&parentMessageId=1697532771278&teamName=Apps%20Team&channelName=iOS&createdTime=1697557532308

## 🚧 **How do we do it?**
I've updated the destination value to ensure it will work with the right device.

## 🧪 **How can I verify this?**
It just affects to tests so if tests pass...