### PR TITLE
feat(Callout): IOS-9818 Adding inverse variant

### DIFF
--- a/Sources/Mistica/Components/Callout/Callout.swift
+++ b/Sources/Mistica/Components/Callout/Callout.swift
@@ -130,7 +130,6 @@ public extension Callout {
 private extension Callout {
     func commomInit() {
         layoutViews()
-        styleViews()
         configureCloseImageView()
     }
 
@@ -145,15 +144,17 @@ private extension Callout {
         ])
     }
 
-    func styleViews() {
-        backgroundColor = .backgroundAlternative
-    }
-
     func configure(withConfiguration configuration: CalloutConfiguration) {
         calloutContentBase.configure(withConfiguration: configuration)
 
         if !configuration.canClose {
             closeImageView.removeFromSuperview()
+        }
+        
+        if configuration.inverse {
+            backgroundColor = .backgroundContainer
+        } else {
+            backgroundColor = .backgroundAlternative
         }
 
         calloutAccessibilityElement.accessibilityLabel = [

--- a/Sources/Mistica/Components/Callout/Callout.swift
+++ b/Sources/Mistica/Components/Callout/Callout.swift
@@ -150,7 +150,7 @@ private extension Callout {
         if !configuration.canClose {
             closeImageView.removeFromSuperview()
         }
-        
+
         if configuration.inverse {
             backgroundColor = .backgroundContainer
         } else {

--- a/Sources/Mistica/Components/Callout/CalloutConfiguration.swift
+++ b/Sources/Mistica/Components/Callout/CalloutConfiguration.swift
@@ -49,7 +49,7 @@ public struct CalloutConfiguration {
         description: String,
         actions: CalloutActions? = nil,
         canClose: Bool = false,
-        inverse: Bool = true
+        inverse: Bool = false
     ) {
         self.asset = asset
         self.title = title

--- a/Sources/Mistica/Components/Callout/CalloutConfiguration.swift
+++ b/Sources/Mistica/Components/Callout/CalloutConfiguration.swift
@@ -33,6 +33,7 @@ public struct CalloutConfiguration {
     let description: String
     let actions: CalloutActions?
     let canClose: Bool
+    let inverse: Bool
 
     /// Callout Configuration to setup the component.
     /// - Parameters:
@@ -41,11 +42,20 @@ public struct CalloutConfiguration {
     ///   - description: This value is mandatory and will be printed as the description title of the callout
     ///   - actions: To know which buttons we must have inside the callout
     ///   - canClose: If true we will have a close button in the top-right to close the callout with an animation
-    public init(asset: CalloutAssetType = .none, title: String? = nil, description: String, actions: CalloutActions? = nil, canClose: Bool = false) {
+    ///   - inverse: If true we will have an inverse variant for background color
+    public init(
+        asset: CalloutAssetType = .none,
+        title: String? = nil,
+        description: String,
+        actions: CalloutActions? = nil,
+        canClose: Bool = false,
+        inverse: Bool = true
+    ) {
         self.asset = asset
         self.title = title
         self.description = description
         self.actions = actions
         self.canClose = canClose
+        self.inverse = inverse
     }
 }

--- a/Sources/MisticaSwiftUI/Components/Callout/Callout.swift
+++ b/Sources/MisticaSwiftUI/Components/Callout/Callout.swift
@@ -111,7 +111,7 @@ public struct Callout<LeadingButton: View, TrailingButton: View>: View {
     private var backgroundColor: Color {
         inverse ? .backgroundContainer : .backgroundAlternative
     }
-    
+
     private var hasButton: Bool {
         LeadingButton.self != EmptyView.self || TrailingButton.self != EmptyView.self
     }
@@ -321,7 +321,7 @@ public extension Callout {
         callout.descriptionAccessibilityIdentifier = descriptionAccessibilityIdentifier
         return callout
     }
-    
+
     func inverseBackground(_ inverse: Bool) -> Callout {
         var callout = self
         callout.inverse = inverse
@@ -343,14 +343,14 @@ public extension Callout {
                         description: "Description",
                         linkButton: { Button("Link") {} }
                     )
-                    
+
                     Callout(
                         assetType: .image(image: .closeButtonBlackSmallIcon),
                         title: "Hola",
                         description: "Description",
                         primaryButton: { Button("Primary") {} }
                     )
-                    
+
                     Callout(
                         assetType: .none,
                         title: "Hola",
@@ -358,9 +358,9 @@ public extension Callout {
                         primaryButton: { Button("Primary") {} },
                         linkButton: { Button("Link") {} }
                     )
-                    
+
                     Callout(description: "Description")
-                    
+
                     Callout(description: "Inverse background")
                         .inverseBackground(false)
                 }.padding()

--- a/Sources/MisticaSwiftUI/Components/Callout/Callout.swift
+++ b/Sources/MisticaSwiftUI/Components/Callout/Callout.swift
@@ -361,7 +361,7 @@ public extension Callout {
 
                     Callout(description: "Description")
 
-                    Callout(description: "Inverse background")
+                    Callout(description: "Not inverse background")
                         .inverseBackground(false)
                 }.padding()
             }

--- a/Sources/MisticaSwiftUI/Components/Callout/Callout.swift
+++ b/Sources/MisticaSwiftUI/Components/Callout/Callout.swift
@@ -341,14 +341,14 @@ public extension Callout {
                     description: "Description",
                     linkButton: { Button("Link") {} }
                 )
-                
+
                 Callout(
                     assetType: .image(image: .closeButtonBlackSmallIcon),
                     title: "Hola",
                     description: "Description",
                     primaryButton: { Button("Primary") {} }
                 )
-                
+
                 Callout(
                     assetType: .none,
                     title: "Hola",
@@ -356,7 +356,7 @@ public extension Callout {
                     primaryButton: { Button("Primary") {} },
                     linkButton: { Button("Link") {} }
                 )
-                
+
                 Callout(description: "Description")
             }.padding()
         }

--- a/Sources/MisticaSwiftUI/Components/Callout/Callout.swift
+++ b/Sources/MisticaSwiftUI/Components/Callout/Callout.swift
@@ -44,7 +44,7 @@ public struct Callout<LeadingButton: View, TrailingButton: View>: View {
         leadingButtonStyle: MisticaButtonStyle,
         trailingButton: TrailingButton,
         trailingButtonStyle: MisticaButtonStyle,
-        inverse: Bool = true
+        inverse: Bool = false
     ) {
         self.assetType = assetType
         self.title = title
@@ -335,36 +335,30 @@ public extension Callout {
 
     struct Callout_Previews: PreviewProvider {
         static var previews: some View {
-            ZStack {
-                Color.backgroundAlternative.edgesIgnoringSafeArea(.all)
-                VStack {
-                    Callout(
-                        title: "Hola",
-                        description: "Description",
-                        linkButton: { Button("Link") {} }
-                    )
-
-                    Callout(
-                        assetType: .image(image: .closeButtonBlackSmallIcon),
-                        title: "Hola",
-                        description: "Description",
-                        primaryButton: { Button("Primary") {} }
-                    )
-
-                    Callout(
-                        assetType: .none,
-                        title: "Hola",
-                        description: "Description",
-                        primaryButton: { Button("Primary") {} },
-                        linkButton: { Button("Link") {} }
-                    )
-
-                    Callout(description: "Description")
-
-                    Callout(description: "Not inverse background")
-                        .inverseBackground(false)
-                }.padding()
-            }
+            VStack {
+                Callout(
+                    title: "Hola",
+                    description: "Description",
+                    linkButton: { Button("Link") {} }
+                )
+                
+                Callout(
+                    assetType: .image(image: .closeButtonBlackSmallIcon),
+                    title: "Hola",
+                    description: "Description",
+                    primaryButton: { Button("Primary") {} }
+                )
+                
+                Callout(
+                    assetType: .none,
+                    title: "Hola",
+                    description: "Description",
+                    primaryButton: { Button("Primary") {} },
+                    linkButton: { Button("Link") {} }
+                )
+                
+                Callout(description: "Description")
+            }.padding()
         }
     }
 #endif

--- a/Sources/MisticaSwiftUI/Components/Callout/Callout.swift
+++ b/Sources/MisticaSwiftUI/Components/Callout/Callout.swift
@@ -33,6 +33,7 @@ public struct Callout<LeadingButton: View, TrailingButton: View>: View {
     private var titleAccessibilityIdentifier: String?
     private var descriptionAccessibilityLabel: String?
     private var descriptionAccessibilityIdentifier: String?
+    private var inverse: Bool
 
     fileprivate init(
         assetType: CalloutAssetType = .none,
@@ -42,7 +43,8 @@ public struct Callout<LeadingButton: View, TrailingButton: View>: View {
         leadingButton: LeadingButton,
         leadingButtonStyle: MisticaButtonStyle,
         trailingButton: TrailingButton,
-        trailingButtonStyle: MisticaButtonStyle
+        trailingButtonStyle: MisticaButtonStyle,
+        inverse: Bool = true
     ) {
         self.assetType = assetType
         self.title = title
@@ -52,6 +54,7 @@ public struct Callout<LeadingButton: View, TrailingButton: View>: View {
         self.leadingButtonStyle = leadingButtonStyle
         self.trailingButton = trailingButton
         self.trailingButtonStyle = trailingButtonStyle
+        self.inverse = inverse
     }
 
     public var body: some View {
@@ -101,10 +104,14 @@ public struct Callout<LeadingButton: View, TrailingButton: View>: View {
             }
         }
         .padding(16)
-        .background(Color.backgroundAlternative)
+        .background(backgroundColor)
         .round(radiusStyle: .container)
     }
 
+    private var backgroundColor: Color {
+        inverse ? .backgroundContainer : .backgroundAlternative
+    }
+    
     private var hasButton: Bool {
         LeadingButton.self != EmptyView.self || TrailingButton.self != EmptyView.self
     }
@@ -314,6 +321,12 @@ public extension Callout {
         callout.descriptionAccessibilityIdentifier = descriptionAccessibilityIdentifier
         return callout
     }
+    
+    func inverseBackground(_ inverse: Bool) -> Callout {
+        var callout = self
+        callout.inverse = inverse
+        return callout
+    }
 }
 
 // MARK: Previews
@@ -322,30 +335,36 @@ public extension Callout {
 
     struct Callout_Previews: PreviewProvider {
         static var previews: some View {
-            VStack {
-                Callout(
-                    title: "Hola",
-                    description: "Description",
-                    linkButton: { Button("Link") {} }
-                )
-
-                Callout(
-                    assetType: .image(image: .closeButtonBlackSmallIcon),
-                    title: "Hola",
-                    description: "Description",
-                    primaryButton: { Button("Primary") {} }
-                )
-
-                Callout(
-                    assetType: .none,
-                    title: "Hola",
-                    description: "Description",
-                    primaryButton: { Button("Primary") {} },
-                    linkButton: { Button("Link") {} }
-                )
-
-                Callout(description: "Description")
-            }.padding()
+            ZStack {
+                Color.backgroundAlternative.edgesIgnoringSafeArea(.all)
+                VStack {
+                    Callout(
+                        title: "Hola",
+                        description: "Description",
+                        linkButton: { Button("Link") {} }
+                    )
+                    
+                    Callout(
+                        assetType: .image(image: .closeButtonBlackSmallIcon),
+                        title: "Hola",
+                        description: "Description",
+                        primaryButton: { Button("Primary") {} }
+                    )
+                    
+                    Callout(
+                        assetType: .none,
+                        title: "Hola",
+                        description: "Description",
+                        primaryButton: { Button("Primary") {} },
+                        linkButton: { Button("Link") {} }
+                    )
+                    
+                    Callout(description: "Description")
+                    
+                    Callout(description: "Inverse background")
+                        .inverseBackground(false)
+                }.padding()
+            }
         }
     }
 #endif


### PR DESCRIPTION
## 🎟️ **Jira ticket**
[IOS-9818](https://jira.tid.es/browse/IOS-9818) Callout inverse variant

## 🥅 **What's the goal?**
We need to behave like Android and allow an inverse (bakground) variant that will be enabled by default with a **backgroundContainer** color, and **backgroundAlternative** when not enabled.

## 🚧 **How do we do it?**
See Android [commit](https://github.com/Telefonica/mistica-android/commit/069dbd6b5ebf0d08d4e0137250ded440791e7f13#diff-c40f0e2acf9b132af8b3f480beeb268b726b561b932380e950e883b0326f9babR163)
