### PR TITLE
Add destination to archive script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ export: clean setup
 	@rm -rf "$(BUILD_PATH)"
 
 	@echo "Archiving..."
-	$(XCODEBUILD) -project "$(PROJECT_PATH)" -scheme $(SCHEMA) clean archive -configuration release -sdk iphoneos -archivePath "$(ARCHIVE_PATH)" | xcbeautify
+	$(XCODEBUILD) -project "$(PROJECT_PATH)" -scheme $(SCHEMA) clean archive -configuration release -sdk iphoneos -archivePath "$(ARCHIVE_PATH)" -destination generic/platform=iOS | xcbeautify
 
 	@echo "Exporting..."
 	$(XCODEBUILD) -exportArchive -archivePath "$(ARCHIVE_PATH)" -exportPath "$(TMP_ROOT_PATH)" -exportOptionsPlist "$(EXPORTED_OPTIONS_PATH)" | xcbeautify


### PR DESCRIPTION
## 🎟️ **Jira ticket**
https://jira.tid.es/browse/IOS-9708

## 🥅 **What's the goal?**
When we create a new Mistica release, it generates a new Mistica Catalog app automatically. This process is failing:
https://github.com/Telefonica/mistica-ios/actions/workflows/build-mistica-catalog.yml?query=event%3Arelease

In the last execution, @WanaldinoTelefonica saw this warning:
https://github.com/Telefonica/mistica-ios/actions/runs/7986232134/job/21806207849#step:6:82

I don't know if it's the same issue as:
> https://teams.microsoft.com/l/message/19:40b9dabcaf1a4abea1216117ac7c0596@thread.tacv2/1708358820438?tenantId=9744600e-3e04-492e-baa1-25ec245c6f10&groupId=992881f8-bbab-4891-8c17-ffe99ba6f43b&parentMessageId=1708358444203&teamName=Apps%20Team&channelName=iOS&createdTime=1708358820438

but at least I'm going to add `-destination` param to remove that warning.

## 🚧 **How do we do it?**
Just added that param

## 🧪 **How can I verify this?**
I cannot check the automatic process but it throws no warnings when manually:
https://github.com/Telefonica/mistica-ios/actions/runs/7991015663/job/21821176224#step:6:148
and the app is created properly:
https://install.appcenter.ms/orgs/tuenti-organization/apps/mistica-swiftui-ios/distribution_groups/public/releases/52
