### PR TITLE
IOS-9656 Add SVG support in UIButtons images

### DIFF
--- a/Sources/Mistica/Utils/Extensions/UIBarButtonItem+Utils.swift
+++ b/Sources/Mistica/Utils/Extensions/UIBarButtonItem+Utils.swift
@@ -51,30 +51,25 @@ extension UIButton {
 }
 
 public extension UIButton {
+    /* 
+     Support SVG Images from URL for UIButton settings
+     */
     func setImageFromURL(url: URL, urlForDarkMode: URL? = nil) {
-        print("TEST - setImageFromURL: \(url)")
         let coder = SDImageSVGCoder.shared
         SDImageCodersManager.shared.addCoder(coder)
 
-        let imageAsset = UIImageAsset()
-
-        sd_setImage(with: url, for: .normal) { lightResult, _, _, _ in
-            print("TEST - lightResult RECEIVED")
-            guard let lightResult else { return }
-            imageAsset.register(lightResult, with: .init(userInterfaceStyle: .light))
+        sd_setImage(with: url, for: .normal) { lightImage, error, _, _ in
+            guard let lightImage else { return }
 
             if let darkURL = urlForDarkMode {
                 self.sd_setImage(with: darkURL, for: .normal) { darkResult, _, _, _ in
                     if let darkImage = darkResult {
-                        imageAsset.register(darkImage, with: .init(userInterfaceStyle: .dark))
-                        print("TEST - setImage WITH DARK")
-
-                        self.setImage(imageAsset.image(with: .current), for: .normal)
+                        lightImage.imageAsset?.register(darkImage, with: .init(userInterfaceStyle: .dark))
+                        self.setImage(lightImage, for: .normal)
                     }
                 }
             } else {
-                print("TEST - setImage")
-                self.setImage(imageAsset.image(with: .current), for: .normal)
+                self.setImage(lightImage, for: .normal)
             }
         }
     }

--- a/Sources/Mistica/Utils/Extensions/UIBarButtonItem+Utils.swift
+++ b/Sources/Mistica/Utils/Extensions/UIBarButtonItem+Utils.swift
@@ -7,6 +7,8 @@
 //
 
 import UIKit
+import SDWebImage
+import SDWebImageSVGCoder
 
 extension UIBarButtonItem {
     convenience init(icon _: UIImage,
@@ -45,5 +47,29 @@ extension UIButton {
         titleLabel?.font = .textPreset3(weight: .regular)
         sizeToFit()
         frameHeight = 36.0
+    }
+
+    func setImageFromURL(url: URL, urlForDarkMode: URL? = nil) {
+        let coder = SDImageSVGCoder.shared
+        SDImageCodersManager.shared.removeCoder(coder)
+        SDImageCodersManager.shared.addCoder(coder)
+
+        let imageAsset = UIImageAsset()
+
+        sd_setImage(with: url, for: .normal) { lightResult, _, _, _ in
+            guard let lightImage = lightResult else { return }
+            imageAsset.register(lightImage, with: .init(userInterfaceStyle: .light))
+
+            if let darkURL = urlForDarkMode {
+                self.sd_setImage(with: darkURL, for: .normal) { darkResult, _, _, _ in
+                    if let darkImage = darkResult {
+                        imageAsset.register(darkImage, with: .init(userInterfaceStyle: .dark))
+                        self.setImage(imageAsset.image(with: self.traitCollection), for: .normal)
+                    }
+                }
+            } else {
+                self.setImage(imageAsset.image(with: self.traitCollection), for: .normal)
+            }
+        }
     }
 }

--- a/Sources/Mistica/Utils/Extensions/UIBarButtonItem+Utils.swift
+++ b/Sources/Mistica/Utils/Extensions/UIBarButtonItem+Utils.swift
@@ -54,12 +54,15 @@ public extension UIButton {
     /*
      Support SVG Images from URL for UIButton settings
      */
-    func setImageFromURL(url: URL, urlForDarkMode: URL? = nil) {
+    func setImageFromURL(url: URL, urlForDarkMode: URL? = nil, defaultImage: UIImage? = nil) {
         let coder = SDImageSVGCoder.shared
         SDImageCodersManager.shared.addCoder(coder)
 
-        sd_setImage(with: url, for: .normal) { lightImage, _, _, _ in
-            guard let lightImage else { return }
+        sd_setImage(with: url, for: .normal) { lightImage, error, _, _ in
+            guard let lightImage else {
+                self.setImage(defaultImage, for: .normal)
+                return
+            }
 
             if let darkURL = urlForDarkMode {
                 self.sd_setImage(with: darkURL, for: .normal) { darkResult, _, _, _ in

--- a/Sources/Mistica/Utils/Extensions/UIBarButtonItem+Utils.swift
+++ b/Sources/Mistica/Utils/Extensions/UIBarButtonItem+Utils.swift
@@ -58,7 +58,7 @@ public extension UIButton {
         let coder = SDImageSVGCoder.shared
         SDImageCodersManager.shared.addCoder(coder)
 
-        sd_setImage(with: url, for: .normal) { lightImage, error, _, _ in
+        sd_setImage(with: url, for: .normal) { lightImage, _, _, _ in
             guard let lightImage else {
                 self.setImage(defaultImage, for: .normal)
                 return

--- a/Sources/Mistica/Utils/Extensions/UIBarButtonItem+Utils.swift
+++ b/Sources/Mistica/Utils/Extensions/UIBarButtonItem+Utils.swift
@@ -52,6 +52,7 @@ extension UIButton {
 
 public extension UIButton {
     func setImageFromURL(url: URL, urlForDarkMode: URL? = nil) {
+        print("TEST - setImageFromURL: \(url)")
         let coder = SDImageSVGCoder.shared
         SDImageCodersManager.shared.removeCoder(coder)
         SDImageCodersManager.shared.addCoder(coder)
@@ -59,17 +60,21 @@ public extension UIButton {
         let imageAsset = UIImageAsset()
 
         sd_setImage(with: url, for: .normal) { lightResult, _, _, _ in
-            guard let lightImage = lightResult else { return }
-            imageAsset.register(lightImage, with: .init(userInterfaceStyle: .light))
+            print("TEST - lightResult RECEIVED")
+            guard let lightResult else { return }
+            imageAsset.register(lightResult, with: .init(userInterfaceStyle: .light))
 
             if let darkURL = urlForDarkMode {
                 self.sd_setImage(with: darkURL, for: .normal) { darkResult, _, _, _ in
                     if let darkImage = darkResult {
                         imageAsset.register(darkImage, with: .init(userInterfaceStyle: .dark))
+                        print("TEST - setImage WITH DARK")
+
                         self.setImage(imageAsset.image(with: self.traitCollection), for: .normal)
                     }
                 }
             } else {
+                print("TEST - setImage")
                 self.setImage(imageAsset.image(with: self.traitCollection), for: .normal)
             }
         }

--- a/Sources/Mistica/Utils/Extensions/UIBarButtonItem+Utils.swift
+++ b/Sources/Mistica/Utils/Extensions/UIBarButtonItem+Utils.swift
@@ -54,7 +54,6 @@ public extension UIButton {
     func setImageFromURL(url: URL, urlForDarkMode: URL? = nil) {
         print("TEST - setImageFromURL: \(url)")
         let coder = SDImageSVGCoder.shared
-        SDImageCodersManager.shared.removeCoder(coder)
         SDImageCodersManager.shared.addCoder(coder)
 
         let imageAsset = UIImageAsset()
@@ -70,12 +69,12 @@ public extension UIButton {
                         imageAsset.register(darkImage, with: .init(userInterfaceStyle: .dark))
                         print("TEST - setImage WITH DARK")
 
-                        self.setImage(imageAsset.image(with: self.traitCollection), for: .normal)
+                        self.setImage(imageAsset.image(with: .current), for: .normal)
                     }
                 }
             } else {
                 print("TEST - setImage")
-                self.setImage(imageAsset.image(with: self.traitCollection), for: .normal)
+                self.setImage(imageAsset.image(with: .current), for: .normal)
             }
         }
     }

--- a/Sources/Mistica/Utils/Extensions/UIBarButtonItem+Utils.swift
+++ b/Sources/Mistica/Utils/Extensions/UIBarButtonItem+Utils.swift
@@ -64,7 +64,7 @@ public extension UIButton {
             if let darkURL = urlForDarkMode {
                 self.sd_setImage(with: darkURL, for: .normal) { darkResult, _, _, _ in
                     if let darkImage = darkResult {
-                        lightImage.imageAsset?.register(darkImage, with: .init(userInterfaceStyle: .dark))
+                        lightImage.imageAsset?.register(darkImage, with: UITraitCollection(traitsFrom: [.current, .init(userInterfaceStyle: .dark)]))
                         self.setImage(lightImage, for: .normal)
                     }
                 }

--- a/Sources/Mistica/Utils/Extensions/UIBarButtonItem+Utils.swift
+++ b/Sources/Mistica/Utils/Extensions/UIBarButtonItem+Utils.swift
@@ -6,9 +6,9 @@
 //  Copyright © Telefonica. All rights reserved.
 //
 
-import UIKit
 import SDWebImage
 import SDWebImageSVGCoder
+import UIKit
 
 extension UIBarButtonItem {
     convenience init(icon _: UIImage,
@@ -51,14 +51,14 @@ extension UIButton {
 }
 
 public extension UIButton {
-    /* 
+    /*
      Support SVG Images from URL for UIButton settings
      */
     func setImageFromURL(url: URL, urlForDarkMode: URL? = nil) {
         let coder = SDImageSVGCoder.shared
         SDImageCodersManager.shared.addCoder(coder)
 
-        sd_setImage(with: url, for: .normal) { lightImage, error, _, _ in
+        sd_setImage(with: url, for: .normal) { lightImage, _, _, _ in
             guard let lightImage else { return }
 
             if let darkURL = urlForDarkMode {

--- a/Sources/Mistica/Utils/Extensions/UIBarButtonItem+Utils.swift
+++ b/Sources/Mistica/Utils/Extensions/UIBarButtonItem+Utils.swift
@@ -48,7 +48,9 @@ extension UIButton {
         sizeToFit()
         frameHeight = 36.0
     }
+}
 
+public extension UIButton {
     func setImageFromURL(url: URL, urlForDarkMode: URL? = nil) {
         let coder = SDImageSVGCoder.shared
         SDImageCodersManager.shared.removeCoder(coder)


### PR DESCRIPTION
## 🎟️ **Jira ticket**
https://jira.tid.es/browse/IOS-9656

## 🥅 **What's the goal?**
To give support to be able to download images from URL that are in SVG format and that we can configure them as image in components like UIButton. This will allow that in apps like Novum we can configure the navigation bar buttons with SVG URLs.

## 🚧 **How do we do it?**
For this purpose, a setImageFromURL method has been implemented in a public extension of UIButton. This method will make use of the SDWebImage library that allows us to download images in SVG format and set them inside the UIButton image.
