### PR TITLE
IOS-9864: Update record-screenshots to also pass the tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,12 @@ on:
   workflow_dispatch:
   pull_request:
         branches: [main]
+  workflow_call:
+    inputs:
+      # The branch, tag or SHA to checkout
+      ref:
+        required: false
+        type: string
 
 jobs:
   test:
@@ -12,7 +18,9 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || '' }}
 
       - name: Build and Test
         run: make test
@@ -22,7 +30,7 @@ jobs:
         run: make extract_tests_attachments
 
       - name: Checkout Telefonica/github-actions repo
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@v4
         if: always()
         with:
           repository: Telefonica/github-actions

--- a/.github/workflows/record-screenshots.yml
+++ b/.github/workflows/record-screenshots.yml
@@ -47,7 +47,7 @@ jobs:
   execute-tests:
     name: Execute tests
     needs: record-screenshots
-    uses: ./.github/workflows/unit-tests.yml
+    uses: ./.github/workflows/ci.yml
     secrets: inherit
     with:
       ref: ${{ needs.record-screenshots.outputs.commit_hash }}

--- a/.github/workflows/record-screenshots.yml
+++ b/.github/workflows/record-screenshots.yml
@@ -1,23 +1,24 @@
-name: Record screenshots
+name: Record screenshots on PR comment
 
 on:
-  workflow_dispatch:
+  issue_comment:
+    types: [created]
 
 jobs:
   record-screenshots:
     name: Record screenshots
+    # Only if it is a PR and the comment contains /record-screenshots
+    if: github.event.issue.pull_request && contains(github.event.comment.body, '/record-screenshots')
     runs-on: self-hosted-novum-mac
     steps:
+      - name: Get branch of PR
+        uses: xt0rted/pull-request-comment-branch@v2
+        id: comment-branch
+
       - name: Checkout
-        uses: actions/checkout@v3
-        
-      - name: Check branch is not main
-        run: |
-          BRANCH_NAME=$(echo ${GITHUB_REF#refs/heads/})
-          if [ "$BRANCH_NAME" == "main" ]; then
-            echo "::error:: Record screenshots aborted since it's on the main branch."
-            exit 0
-          fi
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.comment-branch.outputs.head_sha }}
 
       - name: Enable screenshots recording
         run: |
@@ -32,11 +33,33 @@ jobs:
           find . -type f -name "*.swift" -exec sed -i '' 's/isRecording = true/isRecording = false/' {} +
 
       - name: Commit Changes
-        uses: stefanzweifel/git-auto-commit-action@v4
+        uses: stefanzweifel/git-auto-commit-action@v5
+        id: commit-changes
         with:
+          branch: ${{ steps.comment-branch.outputs.head_ref }}
           file_pattern: '*.png'
           commit_message: Record screenshots automatically launched from GH action
         env:
           GITHUB_TOKEN: ${{ secrets.NOVUM_PRIVATE_REPOS }}
+    outputs:
+      commit_hash: ${{ steps.commit-changes.outputs.commit_hash }}
 
+  execute-tests:
+    name: Execute tests
+    needs: record-screenshots
+    uses: ./.github/workflows/unit-tests.yml
+    secrets: inherit
+    with:
+      ref: ${{ needs.record-screenshots.outputs.commit_hash }}
 
+  set-commit-status:
+    name: Set last commit status
+    if: always() && needs.record-screenshots.result != 'skipped'
+    needs: [record-screenshots, execute-tests]
+    runs-on: self-hosted-novum-mac
+    steps:
+      - uses: myrotvorets/set-commit-status-action@master
+        with:
+          sha: ${{ needs.record-screenshots.outputs.commit_hash }}
+          token: ${{ secrets.NOVUM_PRIVATE_REPOS }}
+          status: ${{ needs.execute-tests.result }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -138,3 +138,7 @@ In order to avoid using `perceptualPrecision` where we could have false tests pa
 <img alt="Rosetta simulator in XCode" src="./doc/images/xcode-rosetta.png">
 
 To check if everything is configured properly, try to execute the tests in `main` where all of them should pass.
+
+### Record new Snapshot testing reference screenshots for a PR
+You can directly generate new reference screenshots using a Github Action in a pull request. That way you can avoid having to generate them in your development Mac and the possible problems.
+To do it, you just need to add a comment to the PR with the text `/record-screenshots` and the Github Action will generate new screenshots, commit them to the PR branch, execute the tests again and update the commit status with the test results.


### PR DESCRIPTION
[IOS-9864](https://jira.tid.es/browse/IOS-9864)

## 🥅 **What's the goal?**
Update the GitHub action to record the screenshots so it also executes the tests.
Also change the action so it is executed by inserting `/record-screenshots` as comment on a PR to avoid branch mistakes and to be able to set the commit and the PR status after passing the tests.

## 🚧 **How do we do it?**
- Execute the tests after recording the screenshots. 
- Launch the action by commenting on a PR.
- Update the latest commit status and thus the PR status with the tests result.
