### PR TITLE
FIX - Add accessibility identifier to dataCard elements

### DIFF
--- a/Sources/Mistica/Components/Cards/DataCard.swift
+++ b/Sources/Mistica/Components/Cards/DataCard.swift
@@ -181,7 +181,7 @@ public extension DataCard {
             cardBaseView.contentView.subtitleIdentifier
         }
         set {
-            cardBaseView.contentView.subtitleIdentifier = newValue
+            cardBaseView.contentView.subtitleIdentifier = newValue == nil ? DataCardAccessibilityIdentifiers.subtitle.rawValue : newValue
             if newValue == nil {
                 cardBaseView.contentView.subtitleIdentifier = DataCardAccessibilityIdentifiers.subtitle.rawValue
             }

--- a/Sources/Mistica/Components/Cards/DataCard.swift
+++ b/Sources/Mistica/Components/Cards/DataCard.swift
@@ -193,7 +193,7 @@ public extension DataCard {
             cardBaseView.contentView.descriptionIdentifier
         }
         set {
-            cardBaseView.contentView.descriptionIdentifier = newValue
+            cardBaseView.contentView.descriptionIdentifier = newValue == nil ? DataCardAccessibilityIdentifiers.description.rawValue : newValue
             if newValue == nil {
                 cardBaseView.contentView.descriptionIdentifier = DataCardAccessibilityIdentifiers.description.rawValue
             }

--- a/Sources/Mistica/Components/Cards/DataCard.swift
+++ b/Sources/Mistica/Components/Cards/DataCard.swift
@@ -154,48 +154,48 @@ public extension DataCard {
 
     var headlineIdentifier: String? {
         get {
-            cardBaseView.contentView.headlineTagView.accessibilityIdentifier
+            cardBaseView.contentView.headlineIdentifier
         }
         set {
-            cardBaseView.contentView.headlineTagView.accessibilityIdentifier = newValue
+            cardBaseView.contentView.headlineIdentifier = newValue
             if newValue == nil {
-                cardBaseView.contentView.headlineTagView.accessibilityIdentifier = DataCardAccessibilityIdentifiers.headline.rawValue
+                cardBaseView.contentView.headlineIdentifier = DataCardAccessibilityIdentifiers.headline.rawValue
             }
         }
     }
 
     var titleIdentifier: String? {
         get {
-            cardBaseView.contentView.titleLabel.accessibilityIdentifier
+            cardBaseView.contentView.titleIdentifier
         }
         set {
-            cardBaseView.contentView.titleLabel.accessibilityIdentifier = newValue
+            cardBaseView.contentView.titleIdentifier = newValue
             if newValue == nil {
-                cardBaseView.contentView.titleLabel.accessibilityIdentifier = DataCardAccessibilityIdentifiers.title.rawValue
+                cardBaseView.contentView.titleIdentifier = DataCardAccessibilityIdentifiers.title.rawValue
             }
         }
     }
 
     var subtitleIdentifier: String? {
         get {
-            cardBaseView.contentView.subtitleLabel.accessibilityIdentifier
+            cardBaseView.contentView.subtitleIdentifier
         }
         set {
-            cardBaseView.contentView.subtitleLabel.accessibilityIdentifier = newValue
+            cardBaseView.contentView.subtitleIdentifier = newValue
             if newValue == nil {
-                cardBaseView.contentView.subtitleLabel.accessibilityIdentifier = DataCardAccessibilityIdentifiers.subtitle.rawValue
+                cardBaseView.contentView.subtitleIdentifier = DataCardAccessibilityIdentifiers.subtitle.rawValue
             }
         }
     }
 
     var descriptionIdentifier: String? {
         get {
-            cardBaseView.contentView.descriptionLabel.accessibilityIdentifier
+            cardBaseView.contentView.descriptionIdentifier
         }
         set {
-            cardBaseView.contentView.descriptionLabel.accessibilityIdentifier = newValue
+            cardBaseView.contentView.descriptionIdentifier = newValue
             if newValue == nil {
-                cardBaseView.contentView.descriptionLabel.accessibilityIdentifier = DataCardAccessibilityIdentifiers.description.rawValue
+                cardBaseView.contentView.descriptionIdentifier = DataCardAccessibilityIdentifiers.description.rawValue
             }
         }
     }

--- a/Sources/Mistica/Components/Cards/DataCard.swift
+++ b/Sources/Mistica/Components/Cards/DataCard.swift
@@ -169,7 +169,7 @@ public extension DataCard {
             cardBaseView.contentView.titleIdentifier
         }
         set {
-            cardBaseView.contentView.titleIdentifier = newValue
+            cardBaseView.contentView.titleIdentifier = newValue == nil ? DataCardAccessibilityIdentifiers.title.rawValue : newValue
             if newValue == nil {
                 cardBaseView.contentView.titleIdentifier = DataCardAccessibilityIdentifiers.title.rawValue
             }

--- a/Sources/Mistica/Components/Cards/DataCard.swift
+++ b/Sources/Mistica/Components/Cards/DataCard.swift
@@ -157,7 +157,7 @@ public extension DataCard {
             cardBaseView.contentView.headlineIdentifier
         }
         set {
-            cardBaseView.contentView.headlineIdentifier = newValue
+            cardBaseView.contentView.headlineIdentifier = newValue == nil ? DataCardAccessibilityIdentifiers.headline.rawValue : newValue
             if newValue == nil {
                 cardBaseView.contentView.headlineIdentifier = DataCardAccessibilityIdentifiers.headline.rawValue
             }

--- a/Sources/Mistica/Components/Cards/Internals/CardCommonContent.swift
+++ b/Sources/Mistica/Components/Cards/Internals/CardCommonContent.swift
@@ -135,7 +135,7 @@ extension CardCommonContent {
             headlineTagView.accessibilityIdentifier
         }
         set {
-            headlineTagView.accessibilityIdentifier = newValue == nil ? DataCardAccessibilityIdentifiers.headline.rawValue : newValue
+            headlineTagView.accessibilityIdentifier = newValue
         }
     }
 
@@ -144,7 +144,7 @@ extension CardCommonContent {
             titleLabel.accessibilityIdentifier
         }
         set {
-            titleLabel.accessibilityIdentifier = newValue == nil ? DataCardAccessibilityIdentifiers.title.rawValue : newValue
+            titleLabel.accessibilityIdentifier = newValue
         }
     }
 
@@ -153,7 +153,7 @@ extension CardCommonContent {
             subtitleLabel.accessibilityIdentifier
         }
         set {
-            subtitleLabel.accessibilityIdentifier = newValue == nil ? DataCardAccessibilityIdentifiers.subtitle.rawValue : newValue
+            subtitleLabel.accessibilityIdentifier = newValue
         }
     }
 
@@ -162,7 +162,7 @@ extension CardCommonContent {
             descriptionLabel.accessibilityIdentifier
         }
         set {
-            descriptionLabel.accessibilityIdentifier = newValue == nil ? DataCardAccessibilityIdentifiers.description.rawValue : newValue
+            descriptionLabel.accessibilityIdentifier = newValue
         }
     }
 }

--- a/Sources/Mistica/Components/Cards/Internals/CardCommonContent.swift
+++ b/Sources/Mistica/Components/Cards/Internals/CardCommonContent.swift
@@ -153,10 +153,7 @@ extension CardCommonContent {
             subtitleLabel.accessibilityIdentifier
         }
         set {
-            subtitleLabel.accessibilityIdentifier = newValue
-            if newValue == nil {
-                subtitleLabel.accessibilityIdentifier = DataCardAccessibilityIdentifiers.subtitle.rawValue
-            }
+            subtitleLabel.accessibilityIdentifier = newValue == nil ? DataCardAccessibilityIdentifiers.subtitle.rawValue : newValue
         }
     }
 

--- a/Sources/Mistica/Components/Cards/Internals/CardCommonContent.swift
+++ b/Sources/Mistica/Components/Cards/Internals/CardCommonContent.swift
@@ -162,10 +162,7 @@ extension CardCommonContent {
             descriptionLabel.accessibilityIdentifier
         }
         set {
-            descriptionLabel.accessibilityIdentifier = newValue
-            if newValue == nil {
-                descriptionLabel.accessibilityIdentifier = DataCardAccessibilityIdentifiers.description.rawValue
-            }
+            descriptionLabel.accessibilityIdentifier = newValue == nil ? DataCardAccessibilityIdentifiers.description.rawValue : newValue
         }
     }
 }

--- a/Sources/Mistica/Components/Cards/Internals/CardCommonContent.swift
+++ b/Sources/Mistica/Components/Cards/Internals/CardCommonContent.swift
@@ -129,7 +129,7 @@ extension CardCommonContent {
             descriptionLabel.topSpacing = newValue
         }
     }
-    
+
     var headlineIdentifier: String? {
         get {
             headlineTagView.accessibilityIdentifier
@@ -177,7 +177,6 @@ extension CardCommonContent {
             }
         }
     }
-
 }
 
 // MARK: Private

--- a/Sources/Mistica/Components/Cards/Internals/CardCommonContent.swift
+++ b/Sources/Mistica/Components/Cards/Internals/CardCommonContent.swift
@@ -144,10 +144,7 @@ extension CardCommonContent {
             titleLabel.accessibilityIdentifier
         }
         set {
-            titleLabel.accessibilityIdentifier = newValue
-            if newValue == nil {
-                titleLabel.accessibilityIdentifier = DataCardAccessibilityIdentifiers.title.rawValue
-            }
+            titleLabel.accessibilityIdentifier = newValue == nil ? DataCardAccessibilityIdentifiers.title.rawValue : newValue
         }
     }
 

--- a/Sources/Mistica/Components/Cards/Internals/CardCommonContent.swift
+++ b/Sources/Mistica/Components/Cards/Internals/CardCommonContent.swift
@@ -135,10 +135,7 @@ extension CardCommonContent {
             headlineTagView.accessibilityIdentifier
         }
         set {
-            headlineTagView.accessibilityIdentifier = newValue
-            if newValue == nil {
-                headlineTagView.accessibilityIdentifier = DataCardAccessibilityIdentifiers.headline.rawValue
-            }
+            headlineTagView.accessibilityIdentifier = newValue == nil ? DataCardAccessibilityIdentifiers.headline.rawValue : newValue
         }
     }
 

--- a/Sources/Mistica/Components/Cards/Internals/CardCommonContent.swift
+++ b/Sources/Mistica/Components/Cards/Internals/CardCommonContent.swift
@@ -129,6 +129,55 @@ extension CardCommonContent {
             descriptionLabel.topSpacing = newValue
         }
     }
+    
+    var headlineIdentifier: String? {
+        get {
+            headlineTagView.accessibilityIdentifier
+        }
+        set {
+            headlineTagView.accessibilityIdentifier = newValue
+            if newValue == nil {
+                headlineTagView.accessibilityIdentifier = DataCardAccessibilityIdentifiers.headline.rawValue
+            }
+        }
+    }
+
+    var titleIdentifier: String? {
+        get {
+            titleLabel.accessibilityIdentifier
+        }
+        set {
+            titleLabel.accessibilityIdentifier = newValue
+            if newValue == nil {
+                titleLabel.accessibilityIdentifier = DataCardAccessibilityIdentifiers.title.rawValue
+            }
+        }
+    }
+
+    var subtitleIdentifier: String? {
+        get {
+            subtitleLabel.accessibilityIdentifier
+        }
+        set {
+            subtitleLabel.accessibilityIdentifier = newValue
+            if newValue == nil {
+                subtitleLabel.accessibilityIdentifier = DataCardAccessibilityIdentifiers.subtitle.rawValue
+            }
+        }
+    }
+
+    var descriptionIdentifier: String? {
+        get {
+            descriptionLabel.accessibilityIdentifier
+        }
+        set {
+            descriptionLabel.accessibilityIdentifier = newValue
+            if newValue == nil {
+                descriptionLabel.accessibilityIdentifier = DataCardAccessibilityIdentifiers.description.rawValue
+            }
+        }
+    }
+
 }
 
 // MARK: Private

--- a/Sources/Mistica/Utils/Views/StackViewContentItem.swift
+++ b/Sources/Mistica/Utils/Views/StackViewContentItem.swift
@@ -52,7 +52,7 @@ class StackViewContentItem<Element: UIView>: UIStackView {
             item[keyPath: keyPath] = newValue
         }
     }
-    
+
     override var accessibilityIdentifier: String? {
         get {
             item.accessibilityIdentifier

--- a/Sources/Mistica/Utils/Views/StackViewContentItem.swift
+++ b/Sources/Mistica/Utils/Views/StackViewContentItem.swift
@@ -52,4 +52,13 @@ class StackViewContentItem<Element: UIView>: UIStackView {
             item[keyPath: keyPath] = newValue
         }
     }
+    
+    override var accessibilityIdentifier: String? {
+        get {
+            item.accessibilityIdentifier
+        }
+        set {
+            item.accessibilityIdentifier = newValue
+        }
+    }
 }


### PR DESCRIPTION
## 🎟️ **Jira ticket**
[IOS-9915](https://jira.tid.es/browse/IOS-9915)

## 🥅 **What's the goal?**
Accessibility identifier was not  being assigned to the expected element. 

## 🚧 **How do we do it?**
The problem is solved by declaring identifier properties till the end of the elements chain of a DataCard.