### PR TITLE
Add default ids for listCellContentView and fix callout component ids

### DIFF
--- a/Sources/Mistica/Components/Callout/Callout.swift
+++ b/Sources/Mistica/Components/Callout/Callout.swift
@@ -131,7 +131,7 @@ public extension Callout {
             closeImageView.accessibilityIdentifier
         }
         set {
-            closeImageView.accessibilityIdentifier = newValue == nil ? CalloutAccessibilityIdentifiers.closeButton.rawValue : newValue
+            closeImageView.accessibilityIdentifier = newValue ?? CalloutAccessibilityIdentifiers.closeButton.rawValue
         }
     }
 

--- a/Sources/Mistica/Components/Callout/Callout.swift
+++ b/Sources/Mistica/Components/Callout/Callout.swift
@@ -125,6 +125,15 @@ public extension Callout {
             calloutContentBase.descriptionIdentifier = newValue
         }
     }
+    
+    var closeIdentifier: String? {
+        get {
+            closeImageView.accessibilityIdentifier
+        }
+        set {
+            closeImageView.accessibilityIdentifier = newValue == nil ? CalloutAccessibilityIdentifiers.closeButton.rawValue : newValue
+        }
+    }
 
     func dismiss(animated: Bool) {
         let completion: (Bool) -> Void = { finished in
@@ -192,6 +201,8 @@ private extension Callout {
 
         closeImageView.isUserInteractionEnabled = true
         closeImageView.addGestureRecognizer(tapGesture)
+        
+        closeImageView.accessibilityIdentifier = CalloutAccessibilityIdentifiers.closeButton.rawValue
     }
 
     @objc func closeButtonTapped() {

--- a/Sources/Mistica/Components/Callout/Callout.swift
+++ b/Sources/Mistica/Components/Callout/Callout.swift
@@ -125,7 +125,7 @@ public extension Callout {
             calloutContentBase.descriptionIdentifier = newValue
         }
     }
-    
+
     var closeIdentifier: String? {
         get {
             closeImageView.accessibilityIdentifier
@@ -201,7 +201,7 @@ private extension Callout {
 
         closeImageView.isUserInteractionEnabled = true
         closeImageView.addGestureRecognizer(tapGesture)
-        
+
         closeImageView.accessibilityIdentifier = CalloutAccessibilityIdentifiers.closeButton.rawValue
     }
 

--- a/Sources/Mistica/Components/Lists/ListCellContentView.swift
+++ b/Sources/Mistica/Components/Lists/ListCellContentView.swift
@@ -302,7 +302,6 @@ public extension ListCellContentView {
             if newValue == nil {
                 centerSection.detailLabel.accessibilityIdentifier = ListAccessibilityIdentifiers.description.rawValue
             }
-
         }
     }
 
@@ -324,7 +323,6 @@ public extension ListCellContentView {
             if newValue == nil {
                 leftSection.accessibilityIdentifier = ListAccessibilityIdentifiers.icon.rawValue
             }
-
         }
     }
 }

--- a/Sources/Mistica/Components/Lists/ListCellContentView.swift
+++ b/Sources/Mistica/Components/Lists/ListCellContentView.swift
@@ -257,6 +257,9 @@ public extension ListCellContentView {
         }
         set {
             centerSection.titleLabel.accessibilityIdentifier = newValue
+            if newValue == nil {
+                centerSection.titleLabel.accessibilityIdentifier = ListAccessibilityIdentifiers.title.rawValue
+            }
         }
     }
 
@@ -275,6 +278,9 @@ public extension ListCellContentView {
         }
         set {
             centerSection.subtitleLabel.accessibilityIdentifier = newValue
+            if newValue == nil {
+                centerSection.subtitleLabel.accessibilityIdentifier = ListAccessibilityIdentifiers.subtitle.rawValue
+            }
         }
     }
 
@@ -293,6 +299,10 @@ public extension ListCellContentView {
         }
         set {
             centerSection.detailLabel.accessibilityIdentifier = newValue
+            if newValue == nil {
+                centerSection.detailLabel.accessibilityIdentifier = ListAccessibilityIdentifiers.description.rawValue
+            }
+
         }
     }
 
@@ -311,6 +321,10 @@ public extension ListCellContentView {
         }
         set {
             leftSection.accessibilityIdentifier = newValue
+            if newValue == nil {
+                leftSection.accessibilityIdentifier = ListAccessibilityIdentifiers.icon.rawValue
+            }
+
         }
     }
 }

--- a/Sources/MisticaCommon/DefaultAccessibilityIdentifiers/CalloutAccessibilityIdentifiers.swift
+++ b/Sources/MisticaCommon/DefaultAccessibilityIdentifiers/CalloutAccessibilityIdentifiers.swift
@@ -13,9 +13,10 @@ private extension DefaultAccessibilityIdentifier.Feature {
 }
 
 public enum CalloutAccessibilityIdentifiers {
-    public static var title = DefaultAccessibilityIdentifier(feature: .callout, section: .item, elementType: .title)
-    public static var description = DefaultAccessibilityIdentifier(feature: .callout, section: .item, elementType: .description)
-    public static var primaryButton = DefaultAccessibilityIdentifier(feature: .callout, section: .item, elementType: .primaryButton)
-    public static var secondaryButton = DefaultAccessibilityIdentifier(feature: .callout, section: .item, elementType: .secondaryButton)
-    public static var linkButton = DefaultAccessibilityIdentifier(feature: .callout, section: .item, elementType: .linkButton)
+    public static var title = DefaultAccessibilityIdentifier(feature: .callout, section: nil, elementType: .title)
+    public static var description = DefaultAccessibilityIdentifier(feature: .callout, section: nil, elementType: .description)
+    public static var primaryButton = DefaultAccessibilityIdentifier(feature: .callout, section: nil, elementType: .primaryButton)
+    public static var secondaryButton = DefaultAccessibilityIdentifier(feature: .callout, section: nil, elementType: .secondaryButton)
+    public static var linkButton = DefaultAccessibilityIdentifier(feature: .callout, section: nil, elementType: .linkButton)
+    public static var closeButton = DefaultAccessibilityIdentifier(feature: .callout, section: nil, elementType: .closeButton)
 }

--- a/Sources/MisticaCommon/DefaultAccessibilityIdentifiers/DefaultAccessibilityIdentifiers.swift
+++ b/Sources/MisticaCommon/DefaultAccessibilityIdentifiers/DefaultAccessibilityIdentifiers.swift
@@ -31,16 +31,16 @@ public struct DefaultAccessibilityIdentifier {
     }
 
     let feature: String
-    let section: String
+    let section: String?
     let elementType: String
 
     public init(
         feature: DefaultAccessibilityIdentifier.Feature,
-        section: DefaultAccessibilityIdentifier.Section,
+        section: DefaultAccessibilityIdentifier.Section?,
         elementType: DefaultAccessibilityIdentifier.ElementType
     ) {
         self.feature = feature.description
-        self.section = section.description
+        self.section = section?.description
         self.elementType = elementType.description
     }
 
@@ -64,6 +64,7 @@ public extension DefaultAccessibilityIdentifier.ElementType {
     static let primaryButton = DefaultAccessibilityIdentifier.ElementType("primary_button")
     static let secondaryButton = DefaultAccessibilityIdentifier.ElementType("secondary_button")
     static let linkButton = DefaultAccessibilityIdentifier.ElementType("link_button")
+    static let closeButton = DefaultAccessibilityIdentifier.ElementType("close_button")
     static let slot = DefaultAccessibilityIdentifier.ElementType("slot")
     static let description = DefaultAccessibilityIdentifier.ElementType("description")
     static let tag = DefaultAccessibilityIdentifier.ElementType("tag")


### PR DESCRIPTION
## 🎟️ **Jira ticket**
[IOS-9930](https://jira.tid.es/browse/IOS-9930)

## 🥅 **What's the goal?**
List rows don't have default accessibility identifiers, so they have been assigned.
Also, according to Figma callout ids, they were incorrect and this PR fix them by removing section value from their id. Now, 
DefaultAccessibilityIdentifier.Section will be optional.
