### PR TITLE
IOS-10003 Fix color token importers with type filter

### DIFF
--- a/_templates/ColorTokenGenerator/BrandColors/BrandColorsAction.ejs.t
+++ b/_templates/ColorTokenGenerator/BrandColors/BrandColorsAction.ejs.t
@@ -37,8 +37,10 @@ struct <%= className %>Colors: MisticaColors {
 }
 
 public struct <%= className %>ColorPalette {
-	public init() {}
-	<%_ Object.keys(jsonObject.jsonData.global.palette).forEach(function(key) { -%>
-	public let <%= key %> = UIColor(hex:"<%= jsonObject.jsonData.global.palette[key].value %>")!
-	<%_ }); -%>
+    public init() {}
+    <%_ Object.keys(jsonObject.jsonData.global.palette).forEach(function(key) { -%>
+        <%_ if (jsonObject.jsonData.global.palette[key].type === "color") { -%>
+    public let <%= key %> = UIColor(hex:"<%= jsonObject.jsonData.global.palette[key].value %>")!
+        <%_ } -%>
+    <%_ }); -%>
 }

--- a/_templates/ColorTokenGenerator/BrandColors/BrandColorsAction.ejs.t
+++ b/_templates/ColorTokenGenerator/BrandColors/BrandColorsAction.ejs.t
@@ -22,17 +22,19 @@ struct <%= className %>Colors: MisticaColors {
 	static let palette = <%= className %>ColorPalette()
 
 	<%_ Object.keys(jsonObject.jsonData.light).forEach(function(key) { -%>
-		<%_ let lightColorString = jsonObject.jsonData.light[key].value -%>
-		<%_ let darkColorString = jsonObject.jsonData.dark[key].value -%>
-		<%_ var lightColor = h.colorFromString(lightColorString, className) -%>
-		<%_ var darkColor = h.colorFromString(darkColorString, className) -%>
-		<%_ if (!!lightColor & !!darkColor) { -%>
-			<%_ if (lightColor == darkColor) { -%>
-	let <%= key %> = <%= lightColor %>
-			<%_ } else { -%>
-	let <%= key %> = <%= lightColor %> | <%= darkColor %>
+	    <%_ if (jsonObject.jsonData.light[key].type === "color") { -%>
+			<%_ let lightColorString = jsonObject.jsonData.light[key].value -%>
+			<%_ let darkColorString = jsonObject.jsonData.dark[key].value -%>
+			<%_ var lightColor = h.colorFromString(lightColorString, className) -%>
+			<%_ var darkColor = h.colorFromString(darkColorString, className) -%>
+			<%_ if (!!lightColor & !!darkColor) { -%>
+				<%_ if (lightColor == darkColor) { -%>
+		let <%= key %> = <%= lightColor %>
+				<%_ } else { -%>
+		let <%= key %> = <%= lightColor %> | <%= darkColor %>
+				<%_ } -%>
 			<%_ } -%>
-		<%_ } -%>
+		<%_ } -%>	
 	<%_ }); -%>
 }
 

--- a/_templates/ColorTokenGenerator/MisticaColors/MisticaColorsAction.ejs.t
+++ b/_templates/ColorTokenGenerator/MisticaColors/MisticaColorsAction.ejs.t
@@ -18,6 +18,8 @@ import UIKit
 
 public protocol MisticaColors {
 <% Object.keys(jsonObject.jsonData.light).forEach(function(key) { -%>
-  var <%= key %>: UIColor { get }
+        <%_ if (jsonObject.jsonData.global.palette[key].type === "color") { -%>
+            var <%= key %>: UIColor { get }
+        <%_ } -%>
 <% }); -%>
 }

--- a/_templates/ColorTokenGenerator/MisticaColors/MisticaColorsAction.ejs.t
+++ b/_templates/ColorTokenGenerator/MisticaColors/MisticaColorsAction.ejs.t
@@ -18,7 +18,7 @@ import UIKit
 
 public protocol MisticaColors {
 <% Object.keys(jsonObject.jsonData.light).forEach(function(key) { -%>
-        <%_ if (jsonObject.jsonData.global.palette[key].type === "color") { -%>
+        <%_ if (jsonObject.jsonData.light[key].type === "color") { -%>
             var <%= key %>: UIColor { get }
         <%_ } -%>
 <% }); -%>

--- a/_templates/ColorTokenGenerator/MisticaColors/ToolkitColorsAction.ejs.t
+++ b/_templates/ColorTokenGenerator/MisticaColors/ToolkitColorsAction.ejs.t
@@ -18,10 +18,11 @@ import SwiftUI
 
 public extension Color {
 <% Object.keys(jsonObject.jsonData.light).forEach(function(key) { -%>
-
-    static var <%= key %>: Color {
-        MisticaConfig.currentColors.<%= key %>.color
-    }
+    <%_ if (jsonObject.jsonData.light[key].type === "color") { -%>
+        static var <%= key %>: Color {
+            MisticaConfig.currentColors.<%= key %>.color
+        }
+    <%_ } -%>
 <% }); -%>
 }
 

--- a/_templates/ColorTokenGenerator/MisticaColors/UIToolkitColorsAction.ejs.t
+++ b/_templates/ColorTokenGenerator/MisticaColors/UIToolkitColorsAction.ejs.t
@@ -18,11 +18,12 @@ import UIKit
 
 public extension UIColor {
 <% Object.keys(jsonObject.jsonData.light).forEach(function(key) { -%>
-
-    @objc(<%= key %>Color)
-    static var <%= key %>: UIColor {
-        MisticaConfig.currentColors.<%= key %>
-    }
+    <%_ if (jsonObject.jsonData.light[key].type === "color") { -%>
+        @objc(<%= key %>Color)
+        static var <%= key %>: UIColor {
+            MisticaConfig.currentColors.<%= key %>
+        }
+    <%_ } -%>
 <% }); -%>
 }
 


### PR DESCRIPTION
## 🎟️ **Jira ticket**
https://jira.tid.es/browse/IOS-10003

## 🥅 **What's the goal?**
Due to the future new gradient tokens and as an improvement to the robustness of the color token importers it is necessary to download only those tokens from the color palette that are of color type. If in the future the color tokens were of gradient type it would create an issue.

## 🚧 **How do we do it?**
Type checkers have been added to each template involved in the generation of color tokens.

## 🧪 **How can I verify this?**
It has been verified that the script is correct by running in terminal:
`make skin ref=production`

The result was that **the new generated color palette doesn't contain the existing gradient token** in the mistica-design json:
https://github.com/Telefonica/mistica-design/blob/e58edd73c4e4877fc8b902f8a2d9a31da5ca8b8a/tokens/movistar.json#L623

**The other tokens remain the same and as before.**

