### PR TITLE
IOS-9797 VIVO Novo app accessibility: Titles in native contents

### DIFF
--- a/Sources/Mistica/Components/Header/HeaderView.swift
+++ b/Sources/Mistica/Components/Header/HeaderView.swift
@@ -179,6 +179,15 @@ public extension HeaderView {
         }
     }
 
+    var titleAccessibilityTraits: UIAccessibilityTraits {
+        get {
+            titleLabel.accessibilityTraits
+        }
+        set {
+            titleLabel.accessibilityTraits = newValue
+        }
+    }
+
     var descriptionAccessibilityLabel: String? {
         get {
             descriptionLabel.accessibilityLabel

--- a/Sources/Mistica/Components/Title/TitleView.swift
+++ b/Sources/Mistica/Components/Title/TitleView.swift
@@ -102,6 +102,21 @@ public class TitleView: UITableViewHeaderFooterView {
     }
 }
 
+// MARK: - Accessibility
+
+public extension TitleView {
+    var titleAccessibilityTraits: UIAccessibilityTraits {
+        get {
+            titleLabel.accessibilityTraits
+        }
+        set {
+            titleLabel.accessibilityTraits = newValue
+        }
+    }
+}
+
+// MARK: - Private methods
+
 private extension TitleView {
     func commonInit() {
         layoutViews()


### PR DESCRIPTION
## 🎟️ **Jira ticket**
[IOS-9797](https://jira.tid.es/browse/IOS-9797) VIVO Novo app accessibility: Titles in native contents

## 🥅 **What's the goal?**
Set as headers:

1. Seguranca e privacidade (Profile)
2. Acceso biometrico e PIN (Profile -> Seguranca e privacidade)
3. PIN entering screens (Profile -> Seguranca e privacidade -> Acceso biometrico e PIN)
4. Acesso a sua conta (Profile -> Acesso a sua conta)
5. Dispositivo atual (Profile -> Acesso a sua conta)
6. Outros dispositivos (Profile -> Acesso a sua conta)

## 🚧 **How do we do it?**
To identify elements as headers, we will use accessibilityTraits using `.header` value. Using this trait, VoiceOver will speak elemens as headers.

Exposed accessibilityTraits for HeaderView and TitleView titles.

## 🧪 **How can I verify this?**
Checking the code
