### PR TITLE
IOS-9786 VIVO Novo app accessibility Assinaturas: decorative images/animation to ignore

### DIFF
--- a/Sources/Mistica/Components/Feedback/FeedbackView.swift
+++ b/Sources/Mistica/Components/Feedback/FeedbackView.swift
@@ -63,7 +63,7 @@ public class FeedbackView: UIView {
             icon.widthAnchor.constraint(equalToConstant: Constants.iconSize),
             icon.heightAnchor.constraint(equalToConstant: Constants.iconSize)
         ])
-        icon.isAccessibilityElement = true
+        icon.isAccessibilityElement = false
         icon.accessibilityIdentifier = DefaultIdentifiers.Feedback.asset
         return icon
     }()
@@ -78,7 +78,7 @@ public class FeedbackView: UIView {
             animation.widthAnchor.constraint(equalToConstant: Constants.iconSize),
             animation.heightAnchor.constraint(equalToConstant: Constants.iconSize)
         ])
-        animation.isAccessibilityElement = true
+        animation.isAccessibilityElement = false
         animation.accessibilityIdentifier = DefaultIdentifiers.Feedback.asset
         return animation
     }()

--- a/Sources/MisticaSwiftUI/Components/Feedback/Feedback.swift
+++ b/Sources/MisticaSwiftUI/Components/Feedback/Feedback.swift
@@ -35,7 +35,6 @@ public struct Feedback<ContentView: View, PrimaryButton: View, SecondaryButton: 
     private var titleAccessibilityIdentifier: String?
     private var messageAccessibilityLabel: String?
     private var messageAccessibilityIdentifier: String?
-    private var imageAccessibilityLabel: String?
     private var imageAccessibilityIdentifier: String?
 
     private var feedbackGenerator = UINotificationFeedbackGenerator()
@@ -70,8 +69,7 @@ public struct Feedback<ContentView: View, PrimaryButton: View, SecondaryButton: 
                         icon
                             .frame(width: Constants.iconHeight, height: Constants.iconHeight, alignment: .bottomLeading)
                             .accessibilityIdentifier(imageAccessibilityIdentifier)
-                            .accessibilityLabel(imageAccessibilityLabel)
-
+                            .misticaBackport.accesibilityHidden(true)
                         Spacer()
                             .frame(height: 24)
 
@@ -352,12 +350,6 @@ public extension Feedback {
         return feedback
     }
 
-    func imageAccessibilityLabel(_ imageAccessibilityLabel: String?) -> Feedback {
-        var feedback = self
-        feedback.imageAccessibilityLabel = imageAccessibilityLabel
-        return feedback
-    }
-
     func imageAccessibilityIdentifier(_ imageAccessibilityIdentifier: String?) -> Feedback {
         var feedback = self
         feedback.imageAccessibilityIdentifier = imageAccessibilityIdentifier
@@ -455,7 +447,6 @@ private extension View {
             .titleAccessibilityIdentifier("Title identifier")
             .messageAccessibilityLabel("Message identifier")
             .messageAccessibilityIdentifier("Message identifier")
-            .imageAccessibilityLabel("Image Label")
             .imageAccessibilityIdentifier("Image identifier")
         }
     }


### PR DESCRIPTION
## 🎟️ **Jira ticket**
[IOS-9786](https://jira.tid.es/browse/IOS-9786) VIVO Novo app accessibility Assinaturas: decorative images/animation to ignore

## 🥅 **What's the goal?**
Exclude feedback icons from accessibility in order to not being spoken by VoiceOver

## 🚧 **How do we do it?**
Used `isAccessibilityElement=false` in UIKit and `.accesibilityHidden(true)` in SwiftUI to exclude icons

## 🧪 **How can I verify this?**
Use Mistica Catalog: Activate VoiceOver and check that icons are not accessibile via VoiceOver

https://github.com/Telefonica/mistica-ios/assets/4386305/55fffa5c-e076-4280-9d98-e31aacc7377f

https://github.com/Telefonica/mistica-ios/assets/4386305/fbab19f3-a66e-4726-a729-e32d2483df61