### PR TITLE
Update record-screenshots action so the status is updated in the PR comment

### DIFF
--- a/.github/workflows/record-screenshots.yml
+++ b/.github/workflows/record-screenshots.yml
@@ -89,7 +89,7 @@ jobs:
           script: |
             const name = '${{ github.workflow	}}';
             const url = '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}';
-            const success = '${{ needs.build-app.result }}' === 'success';
+            const success = '${{ needs.record-screenshots.result }}' === 'success';
             const body = `${name}: ${success ? 'succeeded ✅' : 'failed ❌'}\n${url}`;
             await github.rest.issues.updateComment({
               comment_id: context.payload.comment.id,

--- a/.github/workflows/record-screenshots.yml
+++ b/.github/workflows/record-screenshots.yml
@@ -11,6 +11,20 @@ jobs:
     if: github.event.issue.pull_request && contains(github.event.comment.body, '/record-screenshots')
     runs-on: self-hosted-novum-mac
     steps:
+      - name: Update the comment on PR with link to the job
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const name = '${{ github.workflow	}}';
+            const url = '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}';
+            const body = `${name} launched: ${url}`;
+            await github.rest.issues.updateComment({
+              comment_id: context.payload.comment.id,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: body
+            })
+            
       - name: Get branch of PR
         uses: xt0rted/pull-request-comment-branch@v2
         id: comment-branch
@@ -63,3 +77,23 @@ jobs:
           sha: ${{ needs.record-screenshots.outputs.commit_hash }}
           token: ${{ secrets.NOVUM_PRIVATE_REPOS }}
           status: ${{ needs.execute-tests.result }}
+
+  comment-result-on-pr:
+    name: Add workflow result on PR by updating the comment that triggered the workflow
+    needs: record-screenshots
+    if: always() && needs.record-screenshots.result != 'skipped'
+    runs-on: self-hosted-novum-mac
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const name = '${{ github.workflow	}}';
+            const url = '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}';
+            const success = '${{ needs.build-app.result }}' === 'success';
+            const body = `${name}: ${success ? 'succeeded ✅' : 'failed ❌'}\n${url}`;
+            await github.rest.issues.updateComment({
+              comment_id: context.payload.comment.id,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: body
+            })


### PR DESCRIPTION
## 🥅 **What's the goal?**
Update the record screenshots on PR comment GitHub action so the launched workflow URL and when finished, the final result, is shown o the PR comment that launched the action