### PR TITLE
Reverted change to fix /IOS-10056

### DIFF
--- a/Sources/Mistica/Utils/Extensions/UIBarButtonItem+Utils.swift
+++ b/Sources/Mistica/Utils/Extensions/UIBarButtonItem+Utils.swift
@@ -49,3 +49,31 @@ extension UIButton {
         frameHeight = 36.0
     }
 }
+
+public extension UIButton {
+    /*
+     Support SVG Images from URL for UIButton settings
+     */
+    func setImageFromURL(url: URL, urlForDarkMode: URL? = nil, defaultImage: UIImage? = nil) {
+        let coder = SDImageSVGCoder.shared
+        SDImageCodersManager.shared.addCoder(coder)
+
+        sd_setImage(with: url, for: .normal) { lightImage, _, _, _ in
+            guard let lightImage else {
+                self.setImage(defaultImage, for: .normal)
+                return
+            }
+
+            if let darkURL = urlForDarkMode {
+                self.sd_setImage(with: darkURL, for: .normal) { darkResult, _, _, _ in
+                    if let darkImage = darkResult {
+                        lightImage.imageAsset?.register(darkImage, with: UITraitCollection(traitsFrom: [.current, .init(userInterfaceStyle: .dark)]))
+                        self.setImage(lightImage, for: .normal)
+                    }
+                }
+            } else {
+                self.setImage(lightImage, for: .normal)
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 🎟️ **Jira ticket**
[IOS-10056](https://jira.tid.es/browse/IOS-10056) TopBarButtonItemPresenter.downloadIcons crash

## 🥅 **What's the goal?**
As part of [IOS-10056](https://jira.tid.es/browse/IOS-10056) fix which reverts changes done in https://github.com/Telefonica/mistica-ios/pull/350 we need to restore this code

## 🚧 **How do we do it?**
Restored `UIButton` extension method `setImageFromURL(url:urlForDarkMode:defaultImage:`

## 🧪 **How can I verify this?**
Just check the code