### PR TITLE
IOS-10266 [iOS] Header does not display correctly in initial permissions with iOS 14

### DIFF
--- a/MisticaCatalog/Source/Catalog/Mistica/Components/UICatalogHeaderViewController.swift
+++ b/MisticaCatalog/Source/Catalog/Mistica/Components/UICatalogHeaderViewController.swift
@@ -201,7 +201,7 @@ extension UICatalogHeaderViewController: UITableViewDataSource, UITableViewDeleg
         vc.headerView.title = titleText
         vc.headerView.descriptionValue = descriptionText
 
-        show(vc, sender: self)
+        present(vc, animated: true)
     }
 }
 

--- a/Sources/Mistica/Components/Header/HeaderView.swift
+++ b/Sources/Mistica/Components/Header/HeaderView.swift
@@ -213,7 +213,7 @@ private extension HeaderView {
         addSubview(stackView, constraints: [
             stackView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Constants.marginLeft),
             stackView.topAnchor.constraint(equalTo: topAnchor, constant: Constants.marginTop),
-            stackView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -Constants.marginRight),
+            trailingAnchor.constraint(equalTo: stackView.trailingAnchor, constant: Constants.marginRight),
             bottomAnchor.constraint(equalTo: stackView.bottomAnchor, constant: Constants.marginBottom)
         ])
     }

--- a/Sources/Mistica/Components/Header/HeaderView.swift
+++ b/Sources/Mistica/Components/Header/HeaderView.swift
@@ -32,23 +32,6 @@ public class HeaderView: UIView {
         let stackView = UIStackView()
 
         stackView.axis = .vertical
-        stackView.distribution = .fillProportionally
-        stackView.spacing = Constants.noSpacing
-        stackView.isLayoutMarginsRelativeArrangement = true
-        stackView.layoutMargins = UIEdgeInsets(
-            top: Constants.marginTop,
-            left: Constants.marginLeft,
-            bottom: Constants.marginBottom,
-            right: Constants.marginRight
-        )
-
-        return stackView
-    }()
-
-    private lazy var topStackView: UIStackView = {
-        let stackView = UIStackView()
-
-        stackView.axis = .vertical
         stackView.spacing = Constants.spacing
 
         return stackView
@@ -225,42 +208,40 @@ private extension HeaderView {
         setContentHuggingPriority(.required, for: .vertical)
         setContentCompressionResistancePriority(.required, for: .vertical)
 
-        updateLayoutMarginsGuide()
+        updateColors()
 
         addSubview(stackView, constraints: [
-            stackView.leadingAnchor.constraint(equalTo: leadingAnchor),
-            stackView.topAnchor.constraint(equalTo: topAnchor),
-            stackView.trailingAnchor.constraint(equalTo: trailingAnchor),
-            bottomAnchor.constraint(equalTo: stackView.bottomAnchor)
+            stackView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Constants.marginLeft),
+            stackView.topAnchor.constraint(equalTo: topAnchor, constant: Constants.marginTop),
+            stackView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -Constants.marginRight),
+            bottomAnchor.constraint(equalTo: stackView.bottomAnchor, constant: Constants.marginBottom)
         ])
-
-        stackView.addArrangedSubview(topStackView)
     }
 
     func updateTopStackView() {
         bringSubviewToFront(stackView)
-        topStackView.removeArrangedSubviews()
+        stackView.removeArrangedSubviews()
 
         if let pretitle = pretitle {
             stylePretitleLabel(pretitle)
-            topStackView.addArrangedSubview(pretitleLabel)
+            stackView.addArrangedSubview(pretitleLabel)
 
             let heightLayoutConstraint = pretitleLabel.heightAnchor.constraint(greaterThanOrEqualToConstant: Constants.heightLabel)
-            topStackView.addConstraint(heightLayoutConstraint)
+            stackView.addConstraint(heightLayoutConstraint)
         }
         if let title = title {
             styleTitleLabel(title)
-            topStackView.addArrangedSubview(titleLabel)
+            stackView.addArrangedSubview(titleLabel)
 
             let heightLayoutConstraint = titleLabel.heightAnchor.constraint(greaterThanOrEqualToConstant: Constants.heightLabel)
-            topStackView.addConstraint(heightLayoutConstraint)
+            stackView.addConstraint(heightLayoutConstraint)
         }
         if let descriptionValue = descriptionValue {
             styleDescriptionLabel(descriptionValue)
-            topStackView.addArrangedSubview(descriptionLabel)
+            stackView.addArrangedSubview(descriptionLabel)
 
             let heightLayoutConstraint = descriptionLabel.heightAnchor.constraint(greaterThanOrEqualToConstant: Constants.heightLabel)
-            topStackView.addConstraint(heightLayoutConstraint)
+            stackView.addConstraint(heightLayoutConstraint)
         }
     }
 
@@ -304,16 +285,6 @@ private extension HeaderView {
         case .normalSmall, .inverseSmall:
             return .textPreset2(weight: .regular)
         }
-    }
-
-    func updateLayoutMarginsGuide() {
-        updateColors()
-        directionalLayoutMargins = NSDirectionalEdgeInsets(
-            top: Constants.marginTop,
-            leading: Constants.marginLeft,
-            bottom: Constants.marginBottom,
-            trailing: Constants.marginRight
-        )
     }
 
     func updatePretitleLabelVisibilityState() {


### PR DESCRIPTION
## 🎟️ **Jira ticket**
[IOS-10266](https://jira.tid.es/browse/IOS-10266) [iOS] Header does not display correctly in initial permissions with iOS 14

## 🥅 **What's the goal?**
in iOS 14 the Header component is not displayed correctly, for example in the initial permissions windows.
<img src="https://github.com/Telefonica/mistica-ios/assets/1004932/962a4424-7d1e-48c6-b180-b3b9598f92f9" width="200"/>

## 🚧 **How do we do it?**
There seems to be a problem in iOS 14 when using `layoutMargins` as when integrating it as _Header_ of a _tableView_ it does not calculate the height correctly and the component is displayed incorrectly. 

## 🧪 **How can I verify this?**
|iOS 14 iPhone Xr|iOS 17.2 iPhone 14 Pro|
|--|--|
|<img src="https://github.com/Telefonica/mistica-ios/assets/1004932/a43fdb6c-d55f-4d79-9db7-778aa4013653"/>|<img src="https://github.com/Telefonica/mistica-ios/assets/1004932/e1dcb2ca-0081-4275-aec0-12b54dec4258"/>|

## 🏑 **AppCenter build**
You can use the build generating in Mistica Alpha https://install.appcenter.ms/orgs/tuenti-organization/apps/mistica-swiftui-ios/distribution_groups/public
<img width="685" alt="Screenshot 2024-06-06 at 07 36 56" src="https://github.com/Telefonica/mistica-ios/assets/1004932/ce1c5c10-95d2-4057-af81-e5e4c65a3d01">

