### PR TITLE
IOS-10407 Update textAppBar and backgroundContainerBrand tokens

### DIFF
--- a/Sources/Mistica/Components/Lists/CellStyle+Toolkit.swift
+++ b/Sources/Mistica/Components/Lists/CellStyle+Toolkit.swift
@@ -79,12 +79,12 @@ extension ListCellContentView.CellStyle {
         )
     }
 
-    var backgroundColor: UIColor {
+    var backgroundColor: MisticaColor {
         switch self {
         case .fullWidth:
-            return .background
+            return .solid(.background)
         case .boxed:
-            return .backgroundContainer
+            return .solid(.backgroundContainer)
         case .boxedInverse:
             return .backgroundContainerBrand
         }

--- a/Sources/Mistica/Components/Lists/ListCellContentView.swift
+++ b/Sources/Mistica/Components/Lists/ListCellContentView.swift
@@ -351,7 +351,7 @@ private extension ListCellContentView {
         cellContentView.isLayoutMarginsRelativeArrangement = true
         cellContentView.directionalLayoutMargins = cellStyle.mainStackViewLayoutMargins
 
-        cellBorderView.backgroundColor = cellStyle.backgroundColor
+        cellBorderView.setMisticaColorBackground(cellStyle.backgroundColor)
         cellBorderView.layer.cornerRadius = cellStyle.cornerRadius
         cellBorderView.layer.borderColor = cellStyle.borderColor
         cellBorderView.layer.borderWidth = cellStyle.borderWidth

--- a/Sources/MisticaCommon/Colors/BlauColorPalette.swift
+++ b/Sources/MisticaCommon/Colors/BlauColorPalette.swift
@@ -11,7 +11,7 @@ import UIKit
 struct BlauColors: MisticaColors {
     static let palette = BlauColorPalette()
 
-    let backgroundBrand = MisticaColor.solid(BlauColors.palette.blauBluePrimary | BlauColors.palette.darkModeBlack)
+    let backgroundBrand = BlauColors.palette.blauBluePrimary | BlauColors.palette.darkModeBlack
 
     let backgroundBrandSecondary = BlauColors.palette.blauBluePrimary | BlauColors.palette.darkModeBlack
 

--- a/Sources/MisticaCommon/Colors/BlauColorPalette.swift
+++ b/Sources/MisticaCommon/Colors/BlauColorPalette.swift
@@ -11,7 +11,7 @@ import UIKit
 struct BlauColors: MisticaColors {
     static let palette = BlauColorPalette()
 
-    let backgroundBrand = BlauColors.palette.blauBluePrimary | BlauColors.palette.darkModeBlack
+    let backgroundBrand = MisticaColor.solid(BlauColors.palette.blauBluePrimary | BlauColors.palette.darkModeBlack)
 
     let backgroundBrandSecondary = BlauColors.palette.blauBluePrimary | BlauColors.palette.darkModeBlack
 
@@ -27,7 +27,7 @@ struct BlauColors: MisticaColors {
 
     let backgroundContainerPressed = BlauColors.palette.blauBluePrimary.withAlphaComponent(0.05) | BlauColors.palette.white.withAlphaComponent(0.05)
 
-    let backgroundContainerBrand = BlauColors.palette.blauBluePrimary | BlauColors.palette.darkModeGrey
+    let backgroundContainerBrand = MisticaColor.solid(BlauColors.palette.blauBluePrimary | BlauColors.palette.darkModeGrey)
 
     let backgroundContainerBrandHover = BlauColors.palette.darkModeBlack.withAlphaComponent(0.2) | BlauColors.palette.white.withAlphaComponent(0.03)
 

--- a/Sources/MisticaCommon/Colors/ColorToolkit+Color.swift
+++ b/Sources/MisticaCommon/Colors/ColorToolkit+Color.swift
@@ -17,10 +17,6 @@ public extension Color {
         MisticaConfig.currentColors.backgroundAlternative.color
     }
 
-    static var backgroundBrand: Color {
-        MisticaConfig.currentColors.backgroundBrand.color
-    }
-
     static var backgroundBrandSecondary: Color {
         MisticaConfig.currentColors.backgroundBrandSecondary.color
     }
@@ -39,10 +35,6 @@ public extension Color {
 
     static var backgroundContainerPressed: Color {
         MisticaConfig.currentColors.backgroundContainerPressed.color
-    }
-
-    static var backgroundContainerBrand: Color {
-        MisticaConfig.currentColors.backgroundContainerBrand.color
     }
 
     static var backgroundContainerBrandHover: Color {

--- a/Sources/MisticaCommon/Colors/ColorToolkit+Color.swift
+++ b/Sources/MisticaCommon/Colors/ColorToolkit+Color.swift
@@ -17,6 +17,10 @@ public extension Color {
         MisticaConfig.currentColors.backgroundAlternative.color
     }
 
+    static var backgroundBrand: Color {
+        MisticaConfig.currentColors.backgroundBrand.color
+    }
+
     static var backgroundBrandSecondary: Color {
         MisticaConfig.currentColors.backgroundBrandSecondary.color
     }

--- a/Sources/MisticaCommon/Colors/ColorToolkit+UIColor.swift
+++ b/Sources/MisticaCommon/Colors/ColorToolkit+UIColor.swift
@@ -19,6 +19,11 @@ public extension UIColor {
         MisticaConfig.currentColors.backgroundAlternative
     }
 
+    @objc(backgroundBrandColor)
+    static var backgroundBrand: UIColor {
+        MisticaConfig.currentColors.backgroundBrand
+    }
+
     @objc(backgroundBrandSecondaryColor)
     static var backgroundBrandSecondary: UIColor {
         MisticaConfig.currentColors.backgroundBrandSecondary
@@ -653,7 +658,7 @@ public extension UIColor {
 public extension BrandStyle {
     var preferredStatusBarStyle: UIStatusBarStyle {
         switch self {
-        case .movistar, .vivo, .o2, .o2New, .blau, .custom, .vivoNew, .telefonica, .tu:
+        case .movistar, .vivo, .o2, .o2New, .blau, .custom, .vivoNew, .telefonica:
             return .lightContent
         }
     }

--- a/Sources/MisticaCommon/Colors/ColorToolkit+UIColor.swift
+++ b/Sources/MisticaCommon/Colors/ColorToolkit+UIColor.swift
@@ -19,11 +19,6 @@ public extension UIColor {
         MisticaConfig.currentColors.backgroundAlternative
     }
 
-    @objc(backgroundBrandColor)
-    static var backgroundBrand: UIColor {
-        MisticaConfig.currentColors.backgroundBrand
-    }
-
     @objc(backgroundBrandSecondaryColor)
     static var backgroundBrandSecondary: UIColor {
         MisticaConfig.currentColors.backgroundBrandSecondary
@@ -47,11 +42,6 @@ public extension UIColor {
     @objc(backgroundContainerPressedColor)
     static var backgroundContainerPressed: UIColor {
         MisticaConfig.currentColors.backgroundContainerPressed
-    }
-
-    @objc(backgroundContainerBrandColor)
-    static var backgroundContainerBrand: UIColor {
-        MisticaConfig.currentColors.backgroundContainerBrand
     }
 
     @objc(backgroundContainerBrandHoverColor)
@@ -658,7 +648,7 @@ public extension UIColor {
 public extension BrandStyle {
     var preferredStatusBarStyle: UIStatusBarStyle {
         switch self {
-        case .movistar, .vivo, .o2, .o2New, .blau, .custom, .vivoNew, .telefonica:
+        case .movistar, .vivo, .o2, .o2New, .blau, .custom, .vivoNew, .tu, .telefonica:
             return .lightContent
         }
     }

--- a/Sources/MisticaCommon/Colors/MisticaColor.swift
+++ b/Sources/MisticaCommon/Colors/MisticaColor.swift
@@ -17,7 +17,7 @@ public extension MisticaColor {
     static var backgroundBrand: MisticaColor {
         MisticaConfig.currentColors.backgroundBrand
     }
-    
+
     static var backgroundContainerBrand: MisticaColor {
         MisticaConfig.currentColors.backgroundContainerBrand
     }

--- a/Sources/MisticaCommon/Colors/MisticaColor.swift
+++ b/Sources/MisticaCommon/Colors/MisticaColor.swift
@@ -17,4 +17,8 @@ public extension MisticaColor {
     static var backgroundBrand: MisticaColor {
         MisticaConfig.currentColors.backgroundBrand
     }
+    
+    static var backgroundContainerBrand: MisticaColor {
+        MisticaConfig.currentColors.backgroundContainerBrand
+    }
 }

--- a/Sources/MisticaCommon/Colors/MisticaColors.swift
+++ b/Sources/MisticaCommon/Colors/MisticaColors.swift
@@ -11,7 +11,7 @@ import UIKit
 public protocol MisticaColors {
     var background: UIColor { get }
     var backgroundAlternative: UIColor { get }
-    var backgroundBrand: MisticaColor { get }
+    var backgroundBrand: UIColor { get }
     var backgroundBrandSecondary: UIColor { get }
     var backgroundContainer: UIColor { get }
     var backgroundContainerError: UIColor { get }

--- a/Sources/MisticaCommon/Colors/MisticaColors.swift
+++ b/Sources/MisticaCommon/Colors/MisticaColors.swift
@@ -11,13 +11,13 @@ import UIKit
 public protocol MisticaColors {
     var background: UIColor { get }
     var backgroundAlternative: UIColor { get }
-    var backgroundBrand: UIColor { get }
+    var backgroundBrand: MisticaColor { get }
     var backgroundBrandSecondary: UIColor { get }
     var backgroundContainer: UIColor { get }
     var backgroundContainerError: UIColor { get }
     var backgroundContainerHover: UIColor { get }
     var backgroundContainerPressed: UIColor { get }
-    var backgroundContainerBrand: UIColor { get }
+    var backgroundContainerBrand: MisticaColor { get }
     var backgroundContainerBrandHover: UIColor { get }
     var backgroundContainerBrandPressed: UIColor { get }
     var backgroundContainerBrandOverInverse: UIColor { get }

--- a/Sources/MisticaCommon/Colors/MovistarColorPalette.swift
+++ b/Sources/MisticaCommon/Colors/MovistarColorPalette.swift
@@ -15,7 +15,7 @@ struct MovistarColors: MisticaColors {
 
     let backgroundAlternative = MovistarColors.palette.grey1 | MovistarColors.palette.darkModeBlack
 
-    let backgroundBrand = MisticaColor.solid(MovistarColors.palette.movistarBlue | MovistarColors.palette.darkModeBlack)
+    let backgroundBrand = MovistarColors.palette.movistarBlue | MovistarColors.palette.darkModeBlack
 
     let backgroundBrandSecondary = MovistarColors.palette.movistarBlueDark | MovistarColors.palette.darkModeBlack
 

--- a/Sources/MisticaCommon/Colors/MovistarColorPalette.swift
+++ b/Sources/MisticaCommon/Colors/MovistarColorPalette.swift
@@ -15,7 +15,7 @@ struct MovistarColors: MisticaColors {
 
     let backgroundAlternative = MovistarColors.palette.grey1 | MovistarColors.palette.darkModeBlack
 
-    let backgroundBrand = MovistarColors.palette.movistarBlue | MovistarColors.palette.darkModeBlack
+    let backgroundBrand = MisticaColor.solid(MovistarColors.palette.movistarBlue | MovistarColors.palette.darkModeBlack)
 
     let backgroundBrandSecondary = MovistarColors.palette.movistarBlueDark | MovistarColors.palette.darkModeBlack
 
@@ -27,7 +27,7 @@ struct MovistarColors: MisticaColors {
 
     let backgroundContainerPressed = MovistarColors.palette.black.withAlphaComponent(0.05) | MovistarColors.palette.white.withAlphaComponent(0.05)
 
-    let backgroundContainerBrand = MovistarColors.palette.movistarBlue | MovistarColors.palette.darkModeGrey
+    let backgroundContainerBrand = MisticaColor.solid(MovistarColors.palette.movistarBlue | MovistarColors.palette.darkModeGrey)
 
     let backgroundContainerBrandHover = MovistarColors.palette.black.withAlphaComponent(0.1) | MovistarColors.palette.white.withAlphaComponent(0.03)
 

--- a/Sources/MisticaCommon/Colors/O2ColorPalette.swift
+++ b/Sources/MisticaCommon/Colors/O2ColorPalette.swift
@@ -15,7 +15,7 @@ struct O2Colors: MisticaColors {
 
     let backgroundAlternative = O2Colors.palette.grey1 | O2Colors.palette.darkModeBlack
 
-    let backgroundBrand = MisticaColor.solid(O2Colors.palette.o2BluePrimary | O2Colors.palette.darkModeBlack)
+    let backgroundBrand = O2Colors.palette.o2BluePrimary | O2Colors.palette.darkModeBlack
 
     let backgroundBrandSecondary = O2Colors.palette.o2BluePrimary | O2Colors.palette.darkModeBlack
 

--- a/Sources/MisticaCommon/Colors/O2ColorPalette.swift
+++ b/Sources/MisticaCommon/Colors/O2ColorPalette.swift
@@ -15,7 +15,7 @@ struct O2Colors: MisticaColors {
 
     let backgroundAlternative = O2Colors.palette.grey1 | O2Colors.palette.darkModeBlack
 
-    let backgroundBrand = O2Colors.palette.o2BluePrimary | O2Colors.palette.darkModeBlack
+    let backgroundBrand = MisticaColor.solid(O2Colors.palette.o2BluePrimary | O2Colors.palette.darkModeBlack)
 
     let backgroundBrandSecondary = O2Colors.palette.o2BluePrimary | O2Colors.palette.darkModeBlack
 
@@ -27,7 +27,7 @@ struct O2Colors: MisticaColors {
 
     let backgroundContainerPressed = O2Colors.palette.darkModeBlack.withAlphaComponent(0.05) | O2Colors.palette.white.withAlphaComponent(0.05)
 
-    let backgroundContainerBrand = O2Colors.palette.o2BluePrimary | O2Colors.palette.darkModeGrey
+    let backgroundContainerBrand = MisticaColor.solid(O2Colors.palette.o2BluePrimary | O2Colors.palette.darkModeGrey)
 
     let backgroundContainerBrandHover = O2Colors.palette.darkModeBlack.withAlphaComponent(0.2) | O2Colors.palette.white.withAlphaComponent(0.03)
 

--- a/Sources/MisticaCommon/Colors/O2NewColorPalette.swift
+++ b/Sources/MisticaCommon/Colors/O2NewColorPalette.swift
@@ -12,7 +12,7 @@ struct O2NewColors: MisticaColors {
     static let palette = O2NewColorPalette()
 
     let background = O2NewColors.palette.white | O2NewColors.palette.darkModeBlack
-    
+
     let backgroundBrand = MisticaColor.gradient(MisticaGradient(
         colors:
         [

--- a/Sources/MisticaCommon/Colors/O2NewColorPalette.swift
+++ b/Sources/MisticaCommon/Colors/O2NewColorPalette.swift
@@ -12,6 +12,28 @@ struct O2NewColors: MisticaColors {
     static let palette = O2NewColorPalette()
 
     let background = O2NewColors.palette.white | O2NewColors.palette.darkModeBlack
+    
+    let backgroundBrand = MisticaColor.gradient(MisticaGradient(
+        colors:
+        [
+            O2NewColors.palette.darkBlue | O2NewColors.palette.darkModeBlack,
+            O2NewColors.palette.beyondBlue | O2NewColors.palette.darkModeBlack,
+            O2NewColors.palette.beyondBlue45 | O2NewColors.palette.darkModeBlack
+        ],
+        stops: [0, 0.64, 1],
+        angle: 180
+    ))
+
+    let backgroundContainerBrand = MisticaColor.gradient(MisticaGradient(
+        colors:
+        [
+            O2NewColors.palette.darkBlue | O2NewColors.palette.darkModeGrey,
+            O2NewColors.palette.beyondBlue | O2NewColors.palette.darkModeGrey,
+            O2NewColors.palette.beyondBlue45 | O2NewColors.palette.darkModeGrey
+        ],
+        stops: [0, 0.64, 1],
+        angle: 180
+    ))
 
     let backgroundAlternative = O2NewColors.palette.grey20 | O2NewColors.palette.darkModeBlack
 

--- a/Sources/MisticaCommon/Colors/O2NewColorPalette.swift
+++ b/Sources/MisticaCommon/Colors/O2NewColorPalette.swift
@@ -13,19 +13,6 @@ struct O2NewColors: MisticaColors {
 
     let background = O2NewColors.palette.white | O2NewColors.palette.darkModeBlack
 
-    let backgroundBrand = MisticaColor.gradient(MisticaGradient(
-        colors:
-        [
-            O2NewColors.palette.darkBlue | O2NewColors.palette.darkModeBlack,
-            O2NewColors.palette.beyondBlue | O2NewColors.palette.darkModeBlack,
-            O2NewColors.palette.beyondBlue45 | O2NewColors.palette.darkModeBlack
-        ],
-        stops: [0, 0.64, 1],
-        angle: 180
-    ))
-
-    let backgroundContainerBrand = O2NewColors.palette.beyondBlue | O2NewColors.palette.darkModeGrey
-
     let backgroundAlternative = O2NewColors.palette.grey20 | O2NewColors.palette.darkModeBlack
 
     let backgroundBrandSecondary = O2NewColors.palette.beyondBlue | O2NewColors.palette.darkModeBlack

--- a/Sources/MisticaCommon/Colors/TelefonicaColorPalette.swift
+++ b/Sources/MisticaCommon/Colors/TelefonicaColorPalette.swift
@@ -23,7 +23,7 @@ struct TelefonicaColors: MisticaColors {
 
     let backgroundContainerPressed = TelefonicaColors.palette.telefonicaBlue.withAlphaComponent(0.05) | TelefonicaColors.palette.white.withAlphaComponent(0.05)
 
-    let backgroundContainerBrand = TelefonicaColors.palette.telefonicaBlue | TelefonicaColors.palette.darkModeGrey
+    let backgroundContainerBrand = MisticaColor.solid(TelefonicaColors.palette.telefonicaBlue | TelefonicaColors.palette.darkModeGrey)
 
     let backgroundContainerBrandHover = TelefonicaColors.palette.darkModeBlack.withAlphaComponent(0.2) | TelefonicaColors.palette.white.withAlphaComponent(0.03)
 
@@ -33,7 +33,7 @@ struct TelefonicaColors: MisticaColors {
 
     let backgroundContainerAlternative = TelefonicaColors.palette.grey1 | TelefonicaColors.palette.darkModeGrey
 
-    let backgroundBrand = TelefonicaColors.palette.telefonicaBlue | TelefonicaColors.palette.darkModeBlack
+    let backgroundBrand = MisticaColor.solid(TelefonicaColors.palette.telefonicaBlue | TelefonicaColors.palette.darkModeBlack)
 
     let backgroundBrandSecondary = TelefonicaColors.palette.telefonicaBlue | TelefonicaColors.palette.darkModeBlack
 

--- a/Sources/MisticaCommon/Colors/TelefonicaColorPalette.swift
+++ b/Sources/MisticaCommon/Colors/TelefonicaColorPalette.swift
@@ -33,7 +33,7 @@ struct TelefonicaColors: MisticaColors {
 
     let backgroundContainerAlternative = TelefonicaColors.palette.grey1 | TelefonicaColors.palette.darkModeGrey
 
-    let backgroundBrand = MisticaColor.solid(TelefonicaColors.palette.telefonicaBlue | TelefonicaColors.palette.darkModeBlack)
+    let backgroundBrand = TelefonicaColors.palette.telefonicaBlue | TelefonicaColors.palette.darkModeBlack
 
     let backgroundBrandSecondary = TelefonicaColors.palette.telefonicaBlue | TelefonicaColors.palette.darkModeBlack
 

--- a/Sources/MisticaCommon/Colors/TuColorPalette.swift
+++ b/Sources/MisticaCommon/Colors/TuColorPalette.swift
@@ -23,7 +23,7 @@ struct TuColors: MisticaColors {
 
     let backgroundContainerPressed = TuColors.palette.grey9.withAlphaComponent(0.05) | TuColors.palette.white.withAlphaComponent(0.05)
 
-    let backgroundContainerBrand = TuColors.palette.primary | TuColors.palette.darkModeGrey
+    let backgroundContainerBrand = MisticaColor.solid(TuColors.palette.primary | TuColors.palette.darkModeGrey)
 
     let backgroundContainerBrandHover = TuColors.palette.grey9.withAlphaComponent(0.2) | TuColors.palette.white.withAlphaComponent(0.03)
 
@@ -33,7 +33,7 @@ struct TuColors: MisticaColors {
 
     let backgroundContainerAlternative = TuColors.palette.grey1 | TuColors.palette.darkModeGrey
 
-    let backgroundBrand = TuColors.palette.primary | TuColors.palette.darkModeBlack
+    let backgroundBrand = MisticaColor.solid(TuColors.palette.primary | TuColors.palette.darkModeBlack)
 
     let backgroundBrandSecondary = TuColors.palette.blue | TuColors.palette.darkModeBlack
 

--- a/Sources/MisticaCommon/Colors/TuColorPalette.swift
+++ b/Sources/MisticaCommon/Colors/TuColorPalette.swift
@@ -33,7 +33,7 @@ struct TuColors: MisticaColors {
 
     let backgroundContainerAlternative = TuColors.palette.grey1 | TuColors.palette.darkModeGrey
 
-    let backgroundBrand = MisticaColor.solid(TuColors.palette.primary | TuColors.palette.darkModeBlack)
+    let backgroundBrand = TuColors.palette.primary | TuColors.palette.darkModeBlack
 
     let backgroundBrandSecondary = TuColors.palette.blue | TuColors.palette.darkModeBlack
 

--- a/Sources/MisticaCommon/Colors/VivoColorPalette.swift
+++ b/Sources/MisticaCommon/Colors/VivoColorPalette.swift
@@ -15,7 +15,7 @@ struct VivoColors: MisticaColors {
 
     let backgroundAlternative = VivoColors.palette.grey1 | VivoColors.palette.darkModeBlack
 
-    let backgroundBrand = VivoColors.palette.vivoPurple | VivoColors.palette.darkModeBlack
+    let backgroundBrand = MisticaColor.solid(VivoColors.palette.vivoPurple | VivoColors.palette.darkModeBlack)
 
     let backgroundBrandSecondary = VivoColors.palette.vivoPurple | VivoColors.palette.darkModeBlack
 
@@ -27,7 +27,7 @@ struct VivoColors: MisticaColors {
 
     let backgroundContainerPressed = VivoColors.palette.darkModeBlack.withAlphaComponent(0.05) | VivoColors.palette.white.withAlphaComponent(0.05)
 
-    let backgroundContainerBrand = VivoColors.palette.vivoPurple | VivoColors.palette.darkModeGrey
+    let backgroundContainerBrand = MisticaColor.solid(VivoColors.palette.vivoPurple | VivoColors.palette.darkModeGrey)
 
     let backgroundContainerBrandHover = VivoColors.palette.darkModeBlack.withAlphaComponent(0.2) | VivoColors.palette.white.withAlphaComponent(0.03)
 

--- a/Sources/MisticaCommon/Colors/VivoColorPalette.swift
+++ b/Sources/MisticaCommon/Colors/VivoColorPalette.swift
@@ -15,7 +15,7 @@ struct VivoColors: MisticaColors {
 
     let backgroundAlternative = VivoColors.palette.grey1 | VivoColors.palette.darkModeBlack
 
-    let backgroundBrand = MisticaColor.solid(VivoColors.palette.vivoPurple | VivoColors.palette.darkModeBlack)
+    let backgroundBrand = VivoColors.palette.vivoPurple | VivoColors.palette.darkModeBlack
 
     let backgroundBrandSecondary = VivoColors.palette.vivoPurple | VivoColors.palette.darkModeBlack
 

--- a/Sources/MisticaCommon/Colors/VivoNewColorPalette.swift
+++ b/Sources/MisticaCommon/Colors/VivoNewColorPalette.swift
@@ -15,7 +15,7 @@ struct VivoNewColors: MisticaColors {
 
     let backgroundAlternative = VivoNewColors.palette.grey1 | VivoNewColors.palette.darkModeBlack
 
-    let backgroundBrand = MisticaColor.solid(VivoNewColors.palette.vivoPurple | VivoNewColors.palette.darkModeBlack)
+    let backgroundBrand = VivoNewColors.palette.vivoPurple | VivoNewColors.palette.darkModeBlack
 
     let backgroundBrandSecondary = VivoNewColors.palette.vivoPurpleLight80 | VivoNewColors.palette.darkModeBlack
 
@@ -239,7 +239,7 @@ struct VivoNewColors: MisticaColors {
 
     let textNavigationSearchBarText = VivoNewColors.palette.white | VivoNewColors.palette.grey2
 
-    let textAppBar = VivoNewColors.palette.grey4 | VivoNewColors.palette.grey5
+    let textAppBar = VivoNewColors.palette.grey5
 
     let textAppBarSelected = VivoNewColors.palette.vivoPurple | VivoNewColors.palette.grey2
 

--- a/Sources/MisticaCommon/Colors/VivoNewColorPalette.swift
+++ b/Sources/MisticaCommon/Colors/VivoNewColorPalette.swift
@@ -16,7 +16,7 @@ struct VivoNewColors: MisticaColors {
     let backgroundAlternative = VivoNewColors.palette.grey1 | VivoNewColors.palette.darkModeBlack
 
     let backgroundBrand = MisticaColor.solid(VivoNewColors.palette.vivoPurple | VivoNewColors.palette.darkModeBlack)
-    
+
     let backgroundBrandSecondary = VivoNewColors.palette.vivoPurpleLight80 | VivoNewColors.palette.darkModeBlack
 
     let backgroundContainer = VivoNewColors.palette.white | VivoNewColors.palette.darkModeGrey

--- a/Sources/MisticaCommon/Colors/VivoNewColorPalette.swift
+++ b/Sources/MisticaCommon/Colors/VivoNewColorPalette.swift
@@ -15,8 +15,8 @@ struct VivoNewColors: MisticaColors {
 
     let backgroundAlternative = VivoNewColors.palette.grey1 | VivoNewColors.palette.darkModeBlack
 
-    let backgroundBrand = VivoNewColors.palette.vivoPurple | VivoNewColors.palette.darkModeBlack
-
+    let backgroundBrand = MisticaColor.solid(VivoNewColors.palette.vivoPurple | VivoNewColors.palette.darkModeBlack)
+    
     let backgroundBrandSecondary = VivoNewColors.palette.vivoPurpleLight80 | VivoNewColors.palette.darkModeBlack
 
     let backgroundContainer = VivoNewColors.palette.white | VivoNewColors.palette.darkModeGrey
@@ -27,7 +27,7 @@ struct VivoNewColors: MisticaColors {
 
     let backgroundContainerPressed = VivoNewColors.palette.darkModeBlack.withAlphaComponent(0.05) | VivoNewColors.palette.white.withAlphaComponent(0.05)
 
-    let backgroundContainerBrand = VivoNewColors.palette.vivoPurple | VivoNewColors.palette.darkModeGrey
+    let backgroundContainerBrand = MisticaColor.solid(VivoNewColors.palette.vivoPurple | VivoNewColors.palette.darkModeGrey)
 
     let backgroundContainerBrandHover = VivoNewColors.palette.darkModeBlack.withAlphaComponent(0.2) | VivoNewColors.palette.white.withAlphaComponent(0.03)
 


### PR DESCRIPTION
## 🎟️ **Jira ticket**
https://jira.tid.es/browse/IOS-10407

## 🥅 **What's the goal?**
Update the Mistica tokens, specifically the VivoNew token for the `textAppBar` and the `backgroundContainerBrand` token which can now be a gradient in O2New.

This PR is a fix of the PR generated by @yceballost but with more information and adapted to be integrated:
https://github.com/Telefonica/mistica-ios/pull/380

## 🚧 **How do we do it?**
The most relevant change is the `backgroundBrandContainer` that when taking values of solid color and gradient in function of the skin needs to be a `MisticaColor`.

This change affects the cells of Lists of type boxed inversed. 
