### PR TITLE
Set sheet's title as header for accessibility

### DIFF
--- a/Sources/Mistica/Components/Sheet/View/SheetViewController.swift
+++ b/Sources/Mistica/Components/Sheet/View/SheetViewController.swift
@@ -35,6 +35,7 @@ public class SheetViewController: UIViewController {
             label.textAlignment = .left
             label.textColor = .textPrimary
             label.font = .textPreset5()
+            label.accessibilityTraits = .header
             return label
         }
         return nil


### PR DESCRIPTION
## 🎟️ **Jira ticket**
[IOS-10347](https://jira.tid.es/browse/IOS-10347) Native bottom sheet to be closable and have the right title semantics

## 🥅 **What's the goal?**
As part of [IOS-10347](https://jira.tid.es/browse/IOS-10347) we need to set sheet's titles as header in order to be read as headers by VoiceOver

## 🚧 **How do we do it?**
Set sheet's tilte label accessibility trait to header

## 🧪 **How can I verify this?**
The title should be spoken as "<title_content>, title" by VoiceOver

| Old | New |
|---|---|
| https://github.com/Telefonica/mistica-ios/assets/4386305/1a0ddca7-bf40-451c-8ce9-d24c9a20cc32 | https://github.com/Telefonica/mistica-ios/assets/4386305/ca1e6474-5171-44bc-a3e5-0bcc4746fdb2 |