### PR TITLE
feat(InputField): add option to set textContentType

### DIFF
--- a/Sources/MisticaSwiftUI/Components/Inputfield/InputField.swift
+++ b/Sources/MisticaSwiftUI/Components/Inputfield/InputField.swift
@@ -26,6 +26,7 @@ public struct InputField: View {
 
     public enum Style: Equatable {
         case text
+        case numeric
         case email
         case secure
         case phone(code: String)
@@ -175,7 +176,8 @@ private extension InputField {
             isResponder: $editing,
             isSecured: secure,
             keyboard: keyboard,
-            inputStyle: inputStyle
+            inputStyle: inputStyle, 
+            textContentType: textContentType
         )
     }
 
@@ -185,6 +187,7 @@ private extension InputField {
             return secureActivated
         case .phone,
              .text,
+             .numeric,
              .email,
              .dropdown,
              .date,
@@ -202,6 +205,7 @@ private extension InputField {
         case .phone,
              .secure,
              .text,
+             .numeric,
              .email,
              .search:
             return .text
@@ -218,6 +222,24 @@ private extension InputField {
             return .default
         case .phone:
             return .phonePad
+        case .email:
+            return .emailAddress
+        case .numeric:
+            return .numberPad
+        }
+    }
+    
+    var textContentType: UITextContentType? {
+        switch style {
+        case .secure,
+             .text,
+             .dropdown,
+             .search,
+             .numeric,
+             .date:
+            return nil
+        case .phone:
+            return .telephoneNumber
         case .email:
             return .emailAddress
         }
@@ -261,6 +283,12 @@ public extension InputField {
         view.style = style
         return view
     }
+    
+    func textContentType(_ textContentType: UITextContentType?) -> InputField {
+        var view = self
+        view.textField.textContentType(textContentType)
+        return view
+    }
 }
 
 // MARK: Previews
@@ -274,6 +302,10 @@ struct InputField_Previews: PreviewProvider {
         VStack(alignment: .trailing) {
             InputField(placeholder: "Email", text: $text1)
                 .style(.email)
+                .padding()
+            
+            InputField(placeholder: "Numeric", text: $text1)
+                .style(.numeric)
                 .padding()
 
             InputField(placeholder: "Normal", text: $text1, assistiveText: $assistiveText)

--- a/Sources/MisticaSwiftUI/Components/Inputfield/InputField.swift
+++ b/Sources/MisticaSwiftUI/Components/Inputfield/InputField.swift
@@ -176,7 +176,7 @@ private extension InputField {
             isResponder: $editing,
             isSecured: secure,
             keyboard: keyboard,
-            inputStyle: inputStyle, 
+            inputStyle: inputStyle,
             textContentType: textContentType
         )
     }
@@ -228,7 +228,7 @@ private extension InputField {
             return .numberPad
         }
     }
-    
+
     var textContentType: UITextContentType? {
         switch style {
         case .secure,
@@ -283,7 +283,7 @@ public extension InputField {
         view.style = style
         return view
     }
-    
+
     func textContentType(_ textContentType: UITextContentType?) -> InputField {
         var view = self
         view.textField.textContentType(textContentType)
@@ -303,7 +303,7 @@ struct InputField_Previews: PreviewProvider {
             InputField(placeholder: "Email", text: $text1)
                 .style(.email)
                 .padding()
-            
+
             InputField(placeholder: "Numeric", text: $text1)
                 .style(.numeric)
                 .padding()

--- a/Sources/MisticaSwiftUI/Components/Inputfield/LegacyTextField.swift
+++ b/Sources/MisticaSwiftUI/Components/Inputfield/LegacyTextField.swift
@@ -91,10 +91,10 @@ struct LegacyTextField: UIViewRepresentable {
         toolbar.sizeToFit()
         textField.inputAccessoryView = toolbar
     }
-    
+
     mutating func textContentType(_ contentType: UITextContentType?) {
         textContentType = contentType
-    } 
+    }
 }
 
 // MARK: Coordinator

--- a/Sources/MisticaSwiftUI/Components/Inputfield/LegacyTextField.swift
+++ b/Sources/MisticaSwiftUI/Components/Inputfield/LegacyTextField.swift
@@ -25,6 +25,7 @@ struct LegacyTextField: UIViewRepresentable {
     var isSecured: Bool
     var keyboard: UIKeyboardType
     var inputStyle: LegacyTextFieldInputStyle
+    var textContentType: UITextContentType?
 
     func makeUIView(context: UIViewRepresentableContext<LegacyTextField>) -> UITextField {
         let textField = ActionsTextField(frame: .zero)
@@ -70,6 +71,7 @@ struct LegacyTextField: UIViewRepresentable {
         textField.autocapitalizationType = .none
         textField.autocorrectionType = .no
         textField.keyboardType = keyboard
+        textField.textContentType = textContentType
         textField.delegate = context.coordinator
         textField.textColor = Color.textPrimary.uiColor
 
@@ -89,6 +91,10 @@ struct LegacyTextField: UIViewRepresentable {
         toolbar.sizeToFit()
         textField.inputAccessoryView = toolbar
     }
+    
+    mutating func textContentType(_ contentType: UITextContentType?) {
+        textContentType = contentType
+    } 
 }
 
 // MARK: Coordinator


### PR DESCRIPTION
## 🎟️ **Jira ticket**
[WLLT-1488](https://jira.tid.es/browse/WLLT-1488)

## 🥅 **What's the goal?**
- Add a numeric type to InputField that shows the numeric keyboard
- Add the option to set textContentType to activate the autocompletion of emails, phone numbers, etc

## 🚧 **How do we do it?**
- Add a new Style `numeric`
- Set the keyboard type to `numberPad` for the `numeric` style

## 🧪 **How can I verify this?**
![IMG_805E03E8C7F4-1](https://github.com/user-attachments/assets/ac5d9ddb-f879-4891-8a11-5ae6447ca68c)

![IMG_C311B1DB2138-1](https://github.com/user-attachments/assets/7bdc124a-7e39-4d80-84bd-794386418970)

## 🏑 **AppCenter build**
