### PR TITLE
feat(Snackbar): allow setting the accesibility identifier via SnackbarConfig

### DIFF
--- a/Sources/MisticaCommon/Components/Snackbar/Domain/SnackbarConfig.swift
+++ b/Sources/MisticaCommon/Components/Snackbar/Domain/SnackbarConfig.swift
@@ -72,11 +72,19 @@ public enum SnackbarDismissInterval: Equatable {
 
 public struct SnackbarConfig {
     public let title: String
+    public let titleAccessibilityLabel: String?
+    public let titleAccessibilityIdentifier: String?
     public let dismissInterval: SnackbarDismissInterval
     public let forceDismiss: Bool
 
-    public init(title: String, dismissInterval: SnackbarDismissInterval, forceDismiss: Bool = false) {
+    public init(title: String,
+                titleAccessibilityLabel: String? = nil,
+                titleAccessibilityIdentifier: String? = nil,
+                dismissInterval: SnackbarDismissInterval,
+                forceDismiss: Bool = false) {
         self.title = title
+        self.titleAccessibilityLabel = titleAccessibilityLabel
+        self.titleAccessibilityIdentifier = titleAccessibilityIdentifier
         self.dismissInterval = dismissInterval
         self.forceDismiss = forceDismiss
     }

--- a/Sources/MisticaSwiftUI/Components/Snackbar/Snackbar.swift
+++ b/Sources/MisticaSwiftUI/Components/Snackbar/Snackbar.swift
@@ -57,8 +57,8 @@ public struct Snackbar: View {
                     Text(config.title)
                         .font(.textPreset2(weight: .regular))
                         .foregroundColor(.textPrimaryInverse)
-                        .accessibilityLabel(titleAccessibilityLabel)
-                        .accessibilityIdentifier(titleAccessibilityIdentifier)
+                        .accessibilityLabel(config.titleAccessibilityLabel ?? titleAccessibilityLabel)
+                        .accessibilityIdentifier(config.titleAccessibilityIdentifier ?? titleAccessibilityIdentifier)
                         .expandHorizontally(alignment: .leading)
                     if shouldShowCloseButton {
                         dismissView
@@ -71,8 +71,8 @@ public struct Snackbar: View {
                     Text(config.title)
                         .font(.textPreset2(weight: .regular))
                         .foregroundColor(.textPrimaryInverse)
-                        .accessibilityLabel(titleAccessibilityLabel)
-                        .accessibilityIdentifier(titleAccessibilityIdentifier)
+                        .accessibilityLabel(config.titleAccessibilityLabel ?? titleAccessibilityLabel)
+                        .accessibilityIdentifier(config.titleAccessibilityIdentifier ?? titleAccessibilityIdentifier)
                         .expandHorizontally(alignment: .leading)
                     alignedButton
                     if shouldShowCloseButton {


### PR DESCRIPTION
## 🎟️ **Jira ticket**
[WLLT-1516](https://jira.tid.es/browse/WLLT-1516)

## 🥅 **What's the goal?**
The current way of setting the accessibility identifier of the snarckbar title does not work for the SwiftUI modifier because the methods defined to set it are defined in Snackbar, but the SwiftUI modifier returns `some View` 

## 🚧 **How do we do it?**
Use the existing SnackbarConfig (used to set the title) to set also the accessibility label and identifier if needed

