### PR TITLE
IOS-10545 Fix warnings in XCode 16

### DIFF
--- a/MisticaCatalog/MisticaCatalog.xcodeproj/project.pbxproj
+++ b/MisticaCatalog/MisticaCatalog.xcodeproj/project.pbxproj
@@ -764,7 +764,7 @@
 			repositoryURL = "https://github.com/microsoft/appcenter-sdk-apple";
 			requirement = {
 				kind = exactVersion;
-				version = 4.3.0;
+				version = 5.0.5;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/MisticaCatalog/Source/Catalog/MisticaSwiftUI/Components/EmptyStateCatalogView.swift
+++ b/MisticaCatalog/Source/Catalog/MisticaSwiftUI/Components/EmptyStateCatalogView.swift
@@ -49,7 +49,7 @@ struct EmptyStateCatalogView: View {
 
 // MARK: Helpers
 
-extension EmptyStateAssetType: CustomStringConvertible {
+extension EmptyStateAssetType: Swift.CustomStringConvertible {
     public var description: String {
         switch self {
         case .fullWidth:

--- a/MisticaCatalog/Source/Catalog/MisticaSwiftUI/Components/FeedbackCatalogView.swift
+++ b/MisticaCatalog/Source/Catalog/MisticaSwiftUI/Components/FeedbackCatalogView.swift
@@ -86,7 +86,7 @@ struct FeedbackCatalogView: View {
     }
 }
 
-extension FeedbackStyle: CustomStringConvertible {
+extension FeedbackStyle: Swift.CustomStringConvertible {
     public var description: String {
         switch self {
         case .success:

--- a/MisticaCatalog/Source/Catalog/MisticaSwiftUI/Components/ListCatalogView.swift
+++ b/MisticaCatalog/Source/Catalog/MisticaSwiftUI/Components/ListCatalogView.swift
@@ -131,7 +131,7 @@ extension Image {
     static let netflixLogo = Image("netflix-logo")
 }
 
-extension CellAssetType: CustomStringConvertible {
+extension CellAssetType: Swift.CustomStringConvertible {
     public var description: String {
         switch self {
         case .none:
@@ -148,7 +148,7 @@ extension CellAssetType: CustomStringConvertible {
     }
 }
 
-extension CellStyle: CustomStringConvertible {
+extension CellStyle: Swift.CustomStringConvertible {
     public var description: String {
         switch self {
         case .fullwidth:

--- a/MisticaCatalog/Source/Catalog/MisticaSwiftUI/Components/SnackbarCatalogView.swift
+++ b/MisticaCatalog/Source/Catalog/MisticaSwiftUI/Components/SnackbarCatalogView.swift
@@ -141,7 +141,7 @@ extension SnackbarCatalogView {
 
 // MARK: CustomStringConvertible
 
-extension SnackbarStyle: CustomStringConvertible {
+extension SnackbarStyle: Swift.CustomStringConvertible {
     public var description: String {
         switch self {
         case .normal:
@@ -152,7 +152,7 @@ extension SnackbarStyle: CustomStringConvertible {
     }
 }
 
-extension SnackbarButtonStyle: CustomStringConvertible {
+extension SnackbarButtonStyle: Swift.CustomStringConvertible {
     public var description: String {
         switch self {
         case .large:

--- a/MisticaCatalog/Source/Catalog/MisticaSwiftUI/Components/TagCatalogView.swift
+++ b/MisticaCatalog/Source/Catalog/MisticaSwiftUI/Components/TagCatalogView.swift
@@ -39,7 +39,7 @@ struct TagCatalogView: View {
     }
 }
 
-extension Tag.Style: CustomStringConvertible {
+extension Tag.Style: Swift.CustomStringConvertible {
     public var description: String {
         switch self {
         case .promo:

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,12 +1,12 @@
 {
   "pins" : [
     {
-      "identity" : "lottie-ios",
+      "identity" : "lottie-spm",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/airbnb/lottie-ios.git",
+      "location" : "https://github.com/airbnb/lottie-spm.git",
       "state" : {
-        "revision" : "7fe8b6f697ae7db4bf0df270119592cb5d502848",
-        "version" : "4.4.1"
+        "revision" : "b842598f1295f3ffa1475b1580672d1fe5b83580",
+        "version" : "4.5.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/airbnb/lottie-spm.git", exact: "4.4.0"),
+        .package(url: "https://github.com/airbnb/lottie-spm.git", exact: "4.5.0"),
         .package(url: "https://github.com/pointfreeco/swift-snapshot-testing.git", exact: "1.8.2"),
         .package(url: "https://github.com/SDWebImage/SDWebImage.git", exact: "5.19.1"),
         .package(url: "https://github.com/SDWebImage/SDWebImageSVGCoder.git", exact: "1.7.0")

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/airbnb/lottie-ios.git", exact: "4.4.1"),
+        .package(url: "https://github.com/airbnb/lottie-spm.git", exact: "4.5.0"),
         .package(url: "https://github.com/pointfreeco/swift-snapshot-testing.git", exact: "1.8.2"),
         .package(url: "https://github.com/SDWebImage/SDWebImage.git", exact: "5.19.1"),
         .package(url: "https://github.com/SDWebImage/SDWebImageSVGCoder.git", exact: "1.7.0")
@@ -23,7 +23,7 @@ let package = Package(
         .target(
             name: "MisticaCommon",
             dependencies: [
-                .product(name: "Lottie", package: "lottie-ios")
+                .product(name: "Lottie", package: "lottie-spm")
             ],
             exclude: [
                 "Fonts/README.md",
@@ -57,7 +57,7 @@ let package = Package(
             name: "MisticaSwiftUI",
             dependencies: [
                 "MisticaCommon",
-                .product(name: "Lottie", package: "lottie-ios")
+                .product(name: "Lottie", package: "lottie-spm")
             ],
             exclude: [
                 "Components/Button/README.md",
@@ -101,7 +101,7 @@ let package = Package(
         .target(
             name: "Mistica",
             dependencies: [
-                .product(name: "Lottie", package: "lottie-ios"),
+                .product(name: "Lottie", package: "lottie-spm"),
                 .product(name: "SDWebImage", package: "SDWebImage"),
                 .product(name: "SDWebImageSVGCoder", package: "SDWebImageSVGCoder"),
                 "MisticaCommon"

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/airbnb/lottie-spm.git", exact: "4.5.0"),
+        .package(url: "https://github.com/airbnb/lottie-spm.git", exact: "4.4.0"),
         .package(url: "https://github.com/pointfreeco/swift-snapshot-testing.git", exact: "1.8.2"),
         .package(url: "https://github.com/SDWebImage/SDWebImage.git", exact: "5.19.1"),
         .package(url: "https://github.com/SDWebImage/SDWebImageSVGCoder.git", exact: "1.7.0")

--- a/Sources/Mistica/Components/Button/Button.swift
+++ b/Sources/Mistica/Components/Button/Button.swift
@@ -378,4 +378,4 @@ public extension Button.State {
     static let loading = UIControl.State(rawValue: 1 << 50) // Arbitrary value
 }
 
-extension Button.State: Hashable {}
+extension Button.State: Swift.Hashable {}

--- a/Sources/Mistica/Components/Checkbox/Checkbox.swift
+++ b/Sources/Mistica/Components/Checkbox/Checkbox.swift
@@ -113,7 +113,6 @@ private extension Checkbox {
         addGestureRecognizer(tapGesture)
 
         isAccessibilityElement = true
-        setupAccessibilityTraits()
     }
 
     func layoutView() {
@@ -134,11 +133,6 @@ private extension Checkbox {
 
         let generator = UIImpactFeedbackGenerator(style: .light)
         generator.impactOccurred()
-    }
-
-    @available(iOS, introduced: 11.0, deprecated: 14.0, message: "We're using an undocumented traits of UISwitch. Please verify that this works before increment the deprecated version number")
-    func setupAccessibilityTraits() {
-        accessibilityTraits = UISwitch().accessibilityTraits
     }
 
     func updateViewStyleAnimated(checked: Bool) {

--- a/Sources/MisticaSwiftUI/Components/Inputfield/InputField.swift
+++ b/Sources/MisticaSwiftUI/Components/Inputfield/InputField.swift
@@ -285,8 +285,8 @@ public extension InputField {
     }
 
     func textContentType(_ textContentType: UITextContentType?) -> InputField {
-        var view = self
-        view.textField.textContentType(textContentType)
+        let view = self
+        _ = view.textField.textContentType(textContentType)
         return view
     }
 }


### PR DESCRIPTION
## 🎟️ **Jira ticket**
https://jira.tid.es/browse/IOS-10545

## 🥅 **What's the goal?**
With the release of XCode 16 and Swift 6, new warnings have emerged that can be fixed along with old ones.

## 🚧 **How do we do it?**
The following changes have been made:
- AppCenter framework has been updated to its latest version due to an error in finding an AppCenterDistribute .h file.
- Lottie framework has also been updated as its git address had been changed and it could not find the repository.
- In Swift 6 a new warning has appeared in those modules that conform types like Identifiable, Hashable... in an external way to the module, this can cause that if the module evolves in the future and includes this type there can be conflicts in the code that give error. More information here: 
https://github.com/swiftlang/swift-evolution/blob/main/proposals/0364-retroactive-conformance-warning.md

The solution* is backward-compatible with previous versions of XCode by fully-qualifying all types in the extension. As an example, the above conformance can also be written as

```
extension Foundation.Date: Swift.Identifiable {
    // ...
}
```

_* Another solution that we could perhaps consider in the future would be to wrap the modules that we want to conform those types to avoid doing it in the native modules._