### PR TITLE
Expose titleView backgroundColor in order to customize it refs IOS-10720

### DIFF
--- a/Sources/Mistica/Components/Title/TitleHeaderFooterView.swift
+++ b/Sources/Mistica/Components/Title/TitleHeaderFooterView.swift
@@ -49,7 +49,7 @@ public class TitleHeaderFooterView: UITableViewHeaderFooterView {
         }
     }
     
-    public var titleBackgroundColor: UIColor {
+    public var titleBackgroundColor: UIColor? {
         get {
             titleView.backgroundColor
         }

--- a/Sources/Mistica/Components/Title/TitleHeaderFooterView.swift
+++ b/Sources/Mistica/Components/Title/TitleHeaderFooterView.swift
@@ -48,6 +48,15 @@ public class TitleHeaderFooterView: UITableViewHeaderFooterView {
             titleView.linkTitle = newValue
         }
     }
+    
+    public var titleBackgroundColor: UIColor {
+        get {
+            titleView.backgroundColor
+        }
+        set {
+            titleView.backgroundColor = newValue
+        }
+    }
 
     override public init(reuseIdentifier: String?) {
         super.init(reuseIdentifier: reuseIdentifier)


### PR DESCRIPTION
## 🎟️ **Jira ticket**
[IOS-10720](https://jira.tid.es/browse/IOS-10720) 

## 🥅 **What's the goal?**
In component TitleHeaderFooterView expose TitleView background color in order to be able to customize as it is required by Vivo in Smartwifi.

## 🚧 **How do we do it?**
Exposing titleBackgroundColor property in TitleHeaderFooterView to set TitleView backgroundColor.
