### PR TITLE
IOS-10753 Fix background

### DIFF
--- a/MisticaCatalog/Source/Catalog/Mistica/Components/UICatalogButtonsViewController.swift
+++ b/MisticaCatalog/Source/Catalog/Mistica/Components/UICatalogButtonsViewController.swift
@@ -147,7 +147,7 @@ class UICatalogButtonsViewController: UITableViewController {
             rightImage: style.rightImage
         )
         cell.configure(with: button)
-        cell.contentView.backgroundColor = style.isInverse ? .navigationBarBackground : .backgroundContainer
+        cell.contentView.setMisticaColorBackground(style.isInverse ? .backgroundBrand : .solid(.backgroundContainer))
 
         return cell
     }

--- a/MisticaCatalog/Source/Catalog/MisticaSwiftUI/Components/ButtonCatalogView.swift
+++ b/MisticaCatalog/Source/Catalog/MisticaSwiftUI/Components/ButtonCatalogView.swift
@@ -67,7 +67,12 @@ struct ButtonsCatalogView: View {
 
                         Spacer()
                     }
-                    .listRowBackground(style.inverse ? Color.navigationBarBackground : Color.backgroundContainer)
+                    .listRowBackground(
+                        EmptyView()
+                            .misticaColorView(style.inverse
+                                ? .backgroundBrand
+                                : .solid(.backgroundContainer))
+                    )
                 } header: {
                     Text(style.title)
                 }

--- a/MisticaCatalog/Source/Catalog/MisticaSwiftUI/Components/ButtonCatalogView.swift
+++ b/MisticaCatalog/Source/Catalog/MisticaSwiftUI/Components/ButtonCatalogView.swift
@@ -67,7 +67,7 @@ struct ButtonsCatalogView: View {
 
                         Spacer()
                     }
-                    .listRowBackground(style.inverse ? Color.brand : Color.background)
+                    .listRowBackground(style.inverse ? Color.navigationBarBackground : Color.backgroundContainer)
                 } header: {
                     Text(style.title)
                 }


### PR DESCRIPTION
<!-- This warning is to remind you to check if a designer needs to review this PR. Delete it when you consider it -->
> [!WARNING]
> Should a designer need to review/verify this PR?

## 🎟️ **Jira ticket**
https://jira.tid.es/browse/IOS-10753

## 🥅 **What's the goal?**
wrong background in SwiftUI catalog when it's dark mode and shows inverse links.
![swiftui](https://github.com/user-attachments/assets/5f6d87c8-0b18-4a07-9dea-7725fb287910)


## 🚧 **How do we do it?**
It's already solved in the UIKit catalog, so I've taken the same background colors.

## 🧪 **How can I verify this?**
### Dark
![Captura de pantalla 2024-11-20 a las 12 37 37](https://github.com/user-attachments/assets/8f6084fe-49e9-4cdd-af19-4eeafff49672)


### Light
![Captura de pantalla 2024-11-20 a las 12 37 42](https://github.com/user-attachments/assets/36573434-1b2c-4672-83c7-eae8f65d773c)
