### PR TITLE
IOS-10800 Make ViewStates component in SwiftUI

### DIFF
--- a/MisticaCatalog/MisticaCatalog.xcodeproj/project.pbxproj
+++ b/MisticaCatalog/MisticaCatalog.xcodeproj/project.pbxproj
@@ -53,6 +53,7 @@
 		18E485A4287F19EB0052A6F2 /* UICatalogCroutonViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18E48575287F19EB0052A6F2 /* UICatalogCroutonViewController.swift */; };
 		18E485A5287F19EB0052A6F2 /* UICatalogBadgeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18E48576287F19EB0052A6F2 /* UICatalogBadgeViewController.swift */; };
 		18E485A6287F19EB0052A6F2 /* UICatalogHeaderViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18E48577287F19EB0052A6F2 /* UICatalogHeaderViewController.swift */; };
+		243730502CF74F95008DECFB /* ViewStatesCatalogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2437304F2CF74F95008DECFB /* ViewStatesCatalogView.swift */; };
 		244D00C62C491D4600424AA5 /* SkeletonsCatalogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 244D00C52C491D4600424AA5 /* SkeletonsCatalogView.swift */; };
 		244D00C82C49392700424AA5 /* UICatalogSkeletonsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 244D00C72C49392700424AA5 /* UICatalogSkeletonsViewController.swift */; };
 		24D94F0D2D01D70900CCBEB2 /* FormViewCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24D94F0C2D01D70900CCBEB2 /* FormViewCatalog.swift */; };
@@ -142,6 +143,7 @@
 		18E48575287F19EB0052A6F2 /* UICatalogCroutonViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UICatalogCroutonViewController.swift; sourceTree = "<group>"; };
 		18E48576287F19EB0052A6F2 /* UICatalogBadgeViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UICatalogBadgeViewController.swift; sourceTree = "<group>"; };
 		18E48577287F19EB0052A6F2 /* UICatalogHeaderViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UICatalogHeaderViewController.swift; sourceTree = "<group>"; };
+		2437304F2CF74F95008DECFB /* ViewStatesCatalogView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewStatesCatalogView.swift; sourceTree = "<group>"; };
 		244D00C52C491D4600424AA5 /* SkeletonsCatalogView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkeletonsCatalogView.swift; sourceTree = "<group>"; };
 		244D00C72C49392700424AA5 /* UICatalogSkeletonsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UICatalogSkeletonsViewController.swift; sourceTree = "<group>"; };
 		24D94F0C2D01D70900CCBEB2 /* FormViewCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormViewCatalog.swift; sourceTree = "<group>"; };
@@ -220,6 +222,20 @@
 			isa = PBXGroup;
 			children = (
 				24D94F0C2D01D70900CCBEB2 /* FormViewCatalog.swift */,
+				2437304F2CF74F95008DECFB /* ViewStatesCatalogView.swift */,
+				18E4854D287F19EB0052A6F2 /* InputFieldCatalogView.swift */,
+				18E4854E287F19EB0052A6F2 /* StepperCatalogVIew.swift */,
+				18E4854F287F19EB0052A6F2 /* EmptyStateCatalogView.swift */,
+				18E48550287F19EB0052A6F2 /* SnackbarCatalogView.swift */,
+				18E48551287F19EB0052A6F2 /* CalloutCatalogView.swift */,
+				18E48552287F19EB0052A6F2 /* FeedbackCatalogView.swift */,
+				18E48553287F19EB0052A6F2 /* RadioButtonCatalogView.swift */,
+				18E48554287F19EB0052A6F2 /* CarouselCatalogView.swift */,
+				18E48555287F19EB0052A6F2 /* ChipCatalogView.swift */,
+				18E48556287F19EB0052A6F2 /* ButtonCatalogView.swift */,
+				18E48557287F19EB0052A6F2 /* DataCardCatalogView.swift */,
+				18E48558287F19EB0052A6F2 /* CheckboxCatalogView.swift */,
+				18E48559287F19EB0052A6F2 /* TabsCatalogView.swift */,
 				18E4855A287F19EB0052A6F2 /* BadgeCatalogView.swift */,
 				18E48556287F19EB0052A6F2 /* ButtonCatalogView.swift */,
 				18E48551287F19EB0052A6F2 /* CalloutCatalogView.swift */,
@@ -531,6 +547,7 @@
 				18E4859C287F19EB0052A6F2 /* UICatalogControlsViewController.swift in Sources */,
 				18E485A5287F19EB0052A6F2 /* UICatalogBadgeViewController.swift in Sources */,
 				18E48581287F19EB0052A6F2 /* CalloutCatalogView.swift in Sources */,
+				243730502CF74F95008DECFB /* ViewStatesCatalogView.swift in Sources */,
 				392E03DC28C6153C0081780B /* UICatalogSheetViewController.swift in Sources */,
 				18E48584287F19EB0052A6F2 /* CarouselCatalogView.swift in Sources */,
 				18E485A4287F19EB0052A6F2 /* UICatalogCroutonViewController.swift in Sources */,

--- a/MisticaCatalog/Source/Catalog/CatalogList.swift
+++ b/MisticaCatalog/Source/Catalog/CatalogList.swift
@@ -95,8 +95,9 @@ private extension CatalogRow {
             HeaderCatalogView()
         case .forms:
             FormViewCatalog()
+        case .viewStates:
+            ViewStatesCatalogView()
         case .tooltip,
-             .viewStates,
              .title,
              .filter,
              .scrollContentIndicator,

--- a/MisticaCatalog/Source/Catalog/MisticaSwiftUI/Components/ViewStatesCatalogView.swift
+++ b/MisticaCatalog/Source/Catalog/MisticaSwiftUI/Components/ViewStatesCatalogView.swift
@@ -1,0 +1,99 @@
+//
+//  ViewStatesCatalogView.swift
+//  MisticaCatalog
+//
+//  Created by Alejandro Ruiz on 27/11/24.
+//
+
+
+import SwiftUI
+import MisticaSwiftUI
+
+struct ViewStatesCatalogView: View {
+    private let viewStateTypes: [ViewStateType] = [.loadError]
+    @State var selectedTypeIndex = 0
+    @State private var titleText: String = "Oops, something went wrong"
+    @State private var descriptionText: String = "There was an error loading the content, please, check your network connection and try again later."
+    @State private var actionButtonTitle: String = "Retry"
+    @State private var showActionButton: Bool = true
+    @State private var showState: Bool = false
+
+    var body: some View {
+        ZStack {
+            if !showState {
+                List {
+                    section("View State Type") {
+                        viewStateTypePicker
+                    }
+                    
+                    section("Title (Optional)") {
+                        TextField("Title (Optional)", text: $titleText)
+                    }
+                    
+                    section("Description") {
+                        TextField("Description", text: $descriptionText)
+                    }
+                    
+                    section("Action Button") {
+                        TextField("Action Button Title", text: $actionButtonTitle)
+                        Toggle("Show Action Button", isOn: $showActionButton)
+                    }
+                    
+                    Button("Show State") {
+                        showState = true
+                    }
+                    .buttonStyle(.misticaPrimary())
+                }
+            } else {
+                LoadErrorView(
+                    titleText: titleText.isEmpty ? nil : titleText,
+                    descriptionText: descriptionText.isEmpty ? "Description text is mandatory" : descriptionText,
+                    showActionButton: showActionButton,
+                    actionButtonTitle: actionButtonTitle,
+                    onRetry: {
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+                            showState = false
+                        }
+                    },
+                    onAppear: {
+                        if !showActionButton {
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+                                showState = false
+                            }
+                        }
+                    }
+                )
+            }
+        }
+        .navigationBarTitle("View States")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+    
+    @ViewBuilder
+    var viewStateTypePicker: some View {
+        picker($selectedTypeIndex, options: viewStateTypes)
+    }
+}
+
+enum ViewStateType {
+    case loadError
+}
+
+extension ViewStateType: Swift.CustomStringConvertible {
+    public var description: String {
+        switch self {
+        case .loadError:
+            return "Load error"
+        }
+    }
+}
+
+#if DEBUG
+struct UICatalogViewStatesView_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationView {
+            ViewStatesCatalogView()
+        }
+    }
+}
+#endif

--- a/MisticaCatalog/Source/Catalog/MisticaSwiftUI/Components/ViewStatesCatalogView.swift
+++ b/MisticaCatalog/Source/Catalog/MisticaSwiftUI/Components/ViewStatesCatalogView.swift
@@ -1,13 +1,13 @@
 //
 //  ViewStatesCatalogView.swift
-//  MisticaCatalog
 //
-//  Created by Alejandro Ruiz on 27/11/24.
+//  Made with ❤️ by Novum
+//
+//  Copyright © Telefonica. All rights reserved.
 //
 
-
-import SwiftUI
 import MisticaSwiftUI
+import SwiftUI
 
 struct ViewStatesCatalogView: View {
     private let viewStateTypes: [ViewStateType] = [.loadError]
@@ -25,20 +25,20 @@ struct ViewStatesCatalogView: View {
                     section("View State Type") {
                         viewStateTypePicker
                     }
-                    
+
                     section("Title (Optional)") {
                         TextField("Title (Optional)", text: $titleText)
                     }
-                    
+
                     section("Description") {
                         TextField("Description", text: $descriptionText)
                     }
-                    
+
                     section("Action Button") {
                         TextField("Action Button Title", text: $actionButtonTitle)
                         Toggle("Show Action Button", isOn: $showActionButton)
                     }
-                    
+
                     Button("Show State") {
                         showState = true
                     }
@@ -68,7 +68,7 @@ struct ViewStatesCatalogView: View {
         .navigationBarTitle("View States")
         .navigationBarTitleDisplayMode(.inline)
     }
-    
+
     @ViewBuilder
     var viewStateTypePicker: some View {
         picker($selectedTypeIndex, options: viewStateTypes)
@@ -89,11 +89,11 @@ extension ViewStateType: Swift.CustomStringConvertible {
 }
 
 #if DEBUG
-struct UICatalogViewStatesView_Previews: PreviewProvider {
-    static var previews: some View {
-        NavigationView {
-            ViewStatesCatalogView()
+    struct UICatalogViewStatesView_Previews: PreviewProvider {
+        static var previews: some View {
+            NavigationView {
+                ViewStatesCatalogView()
+            }
         }
     }
-}
 #endif

--- a/Sources/MisticaSwiftUI/Components/ViewStates/LoadErrorView.swift
+++ b/Sources/MisticaSwiftUI/Components/ViewStates/LoadErrorView.swift
@@ -63,7 +63,7 @@ public struct LoadErrorView: View {
                         Text(actionButtonTitle)
                     }
                     .loading(isRetryButtonLoading)
-                    .buttonStyle(.misticaSecondary(small: true))
+                    .buttonStyle(.misticaSecondary(small: false))
                 }
             }
             .padding(.horizontal, Constants.contentInset)

--- a/Sources/MisticaSwiftUI/Components/ViewStates/LoadErrorView.swift
+++ b/Sources/MisticaSwiftUI/Components/ViewStates/LoadErrorView.swift
@@ -13,22 +13,22 @@ public struct LoadErrorView: View {
         static let contentInset: CGFloat = 24
         static let verticalSpacing: CGFloat = 16
     }
-    
+
     @State var isRetryButtonLoading: Bool = false
-    
+
     let titleText: String?
     let descriptionText: String
     let showActionButton: Bool
     let actionButtonTitle: String
     let onRetry: () -> Void
     let onAppear: (() -> Void)?
-    
+
     public init(titleText: String?,
                 descriptionText: String,
                 showActionButton: Bool,
                 actionButtonTitle: String,
                 onRetry: @escaping () -> Void,
-                onAppear: ( () -> Void)?)
+                onAppear: (() -> Void)?)
     {
         self.titleText = titleText
         self.descriptionText = descriptionText
@@ -48,13 +48,13 @@ public struct LoadErrorView: View {
                         .multilineTextAlignment(.center)
                         .lineLimit(nil)
                 }
-                
+
                 Text(descriptionText)
                     .font(.textPreset3(weight: .regular))
                     .foregroundColor(.textSecondary)
                     .multilineTextAlignment(.center)
                     .lineLimit(nil)
-                
+
                 if showActionButton {
                     Button(action: {
                         isRetryButtonLoading = true

--- a/Sources/MisticaSwiftUI/Components/ViewStates/LoadErrorView.swift
+++ b/Sources/MisticaSwiftUI/Components/ViewStates/LoadErrorView.swift
@@ -1,0 +1,88 @@
+//
+//  LoadErrorView.swift
+//
+//  Made with ❤️ by Novum
+//
+//  Copyright © Telefonica. All rights reserved.
+//
+
+import SwiftUI
+
+public struct LoadErrorView: View {
+    private enum Constants {
+        static let contentInset: CGFloat = 24
+        static let verticalSpacing: CGFloat = 16
+    }
+    
+    @State var isRetryButtonLoading: Bool = false
+    
+    let titleText: String?
+    let descriptionText: String
+    let showActionButton: Bool
+    let actionButtonTitle: String
+    let onRetry: () -> Void
+    let onAppear: (() -> Void)?
+    
+    public init(titleText: String?,
+                descriptionText: String,
+                showActionButton: Bool,
+                actionButtonTitle: String,
+                onRetry: @escaping () -> Void,
+                onAppear: ( () -> Void)?)
+    {
+        self.titleText = titleText
+        self.descriptionText = descriptionText
+        self.showActionButton = showActionButton
+        self.actionButtonTitle = actionButtonTitle
+        self.onRetry = onRetry
+        self.onAppear = onAppear
+    }
+
+    public var body: some View {
+        VStack {
+            VStack(alignment: .center, spacing: Constants.verticalSpacing) {
+                if let titleText = titleText {
+                    Text(titleText)
+                        .font(.textPreset4(weight: .cardTitle))
+                        .foregroundColor(.textPrimary)
+                        .multilineTextAlignment(.center)
+                        .lineLimit(nil)
+                }
+                
+                Text(descriptionText)
+                    .font(.textPreset3(weight: .regular))
+                    .foregroundColor(.textSecondary)
+                    .multilineTextAlignment(.center)
+                    .lineLimit(nil)
+                
+                if showActionButton {
+                    Button(action: {
+                        isRetryButtonLoading = true
+                        onRetry()
+                    }) {
+                        Text(actionButtonTitle)
+                    }
+                    .loading(isRetryButtonLoading)
+                    .buttonStyle(.misticaSecondary(small: true))
+                }
+            }
+            .padding(.horizontal, Constants.contentInset)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+
+// MARK: - Preview
+
+struct LoadErrorView_Previews: PreviewProvider {
+    static var previews: some View {
+        LoadErrorView(
+            titleText: "Oops, something went wrong",
+            descriptionText: "There was an error loading the content, please, check your network connection and try again later.",
+            showActionButton: true,
+            actionButtonTitle: "Retry",
+            onRetry: {},
+            onAppear: {}
+        )
+    }
+}


### PR DESCRIPTION
## 🎟️ **Jira ticket**
https://jira.tid.es/browse/IOS-10800

## 🥅 **What's the goal?**
As a performance objective to make SwiftUI components, ViewStates component will be migrated from UIKit to SwiftUI.

## 🚧 **How do we do it?**
A new component similar to the component in UIKit has been created and added inside the Catalog.

## 🧪 **How can I verify this?**
**FOR DESIGN MEMBER** (@AnaMontes11) : There is a difference between the buttons we have for SwiftUI and the UIKit buttons, I'm not clear which one should be the correct one since I can't find references to the Design of this component. I hope that in the revision of this PR a member of Design can clarify it.

If the SwiftUI design is correct, it could be used as a base and apply in UIKit a wrapper that encapsulates the SwiftUI design to use the same design in all platforms.

| SwiftUI | UIKit |
|---|---|
| <img width="330" alt="Screenshot 2023-10-03 at 15 27 29" src="https://github.com/user-attachments/assets/37bd38a9-af2e-4408-b83b-eb7c056e5400"> |<img width="330" alt="Screenshot 2023-10-03 at 15 30 48" src="https://github.com/user-attachments/assets/37cf2275-23b8-4b09-9152-59498abebddf">|

## 🏑 **AppCenter build**
<img width="147" alt="Screenshot 2024-11-29 at 12 12 00" src="https://github.com/user-attachments/assets/3b5b2d2f-d1d6-48f2-91bf-bf0199cbd1cf">

