### PR TITLE
IOS-10544 Add safe concurrency in Feedback completion

### DIFF
--- a/Sources/Mistica/Components/Feedback/Model/FeedbackConfiguration.swift
+++ b/Sources/Mistica/Components/Feedback/Model/FeedbackConfiguration.swift
@@ -10,7 +10,7 @@ import Foundation
 import UIKit
 
 public typealias FeedbackCompletion = () -> Void
-public typealias FeedbackRetryCompletion = (@MainActor @escaping @Sendable () -> Void) -> Void
+public typealias FeedbackRetryCompletion = @MainActor (@escaping @Sendable () -> Void) -> Void
 
 @frozen
 public enum FeedbackPrimaryAction {

--- a/Sources/Mistica/Components/Feedback/Model/FeedbackConfiguration.swift
+++ b/Sources/Mistica/Components/Feedback/Model/FeedbackConfiguration.swift
@@ -10,7 +10,7 @@ import Foundation
 import UIKit
 
 public typealias FeedbackCompletion = () -> Void
-public typealias FeedbackRetryCompletion = (@escaping () -> Void) -> Void
+public typealias FeedbackRetryCompletion = (@escaping @Sendable () -> Void) -> Void
 
 @frozen
 public enum FeedbackPrimaryAction {

--- a/Sources/Mistica/Components/Feedback/Model/FeedbackConfiguration.swift
+++ b/Sources/Mistica/Components/Feedback/Model/FeedbackConfiguration.swift
@@ -10,7 +10,7 @@ import Foundation
 import UIKit
 
 public typealias FeedbackCompletion = () -> Void
-public typealias FeedbackRetryCompletion = (@escaping @Sendable () -> Void) -> Void
+public typealias FeedbackRetryCompletion = (@MainActor @escaping @Sendable () -> Void) -> Void
 
 @frozen
 public enum FeedbackPrimaryAction {

--- a/Sources/Mistica/Components/Feedback/Model/FeedbackConfiguration.swift
+++ b/Sources/Mistica/Components/Feedback/Model/FeedbackConfiguration.swift
@@ -10,7 +10,7 @@ import Foundation
 import UIKit
 
 public typealias FeedbackCompletion = () -> Void
-public typealias FeedbackRetryCompletion = @MainActor (@escaping @Sendable () -> Void) -> Void
+public typealias FeedbackRetryCompletion = @MainActor(@escaping @Sendable() -> Void) -> Void
 
 @frozen
 public enum FeedbackPrimaryAction {


### PR DESCRIPTION
## 🎟️ **Jira ticket**
https://jira.tid.es/browse/IOS-10544

## 🥅 **What's the goal?**
Due to the migration to Swift 6 with strict concurrency that we are doing in Novum it is necessary to add some changes in the completion of Feedback so that it can be compatible with apps migrated in Swift 6.

## 🚧 **How do we do it?**
Since it is a visual component that requires UI actions, its completion action is isolated in a main actor environment and its parameters will be `Sendable` to ensure safe concurrency.

## 🧪 **How can I verify this?**
This fix will be used from this PR in Novum:
https://github.com/Telefonica/iphoneapp/pull/1792