### PR TITLE
IOS-10974 Allow ref param

### DIFF
--- a/.github/workflows/generate-mistica-tokens.yml
+++ b/.github/workflows/generate-mistica-tokens.yml
@@ -2,6 +2,11 @@ name: Generate Mistica Tokens
 
 on:
   workflow_dispatch:
+    inputs:
+      ref:
+        description: 'mistica-design repo changeset or branch'
+        required: false
+        default: 'production'
 
 concurrency:
     group: ci-${{ github.ref }}
@@ -23,7 +28,7 @@ jobs:
       working-directory: scripts/mistica-skin-generator
 
     - name: Generate tokens
-      run: npm run generate
+      run: npm run generate -- ${{github.event.inputs.ref}}
       working-directory: scripts/mistica-skin-generator
 
     - name: Create Pull Request

--- a/scripts/mistica-skin-generator/index.js
+++ b/scripts/mistica-skin-generator/index.js
@@ -59,10 +59,16 @@ const BRANDS = [
 const BRANCH = 'production';
 
 const run = async () => {
+    let branch = BRANCH;
+    if (process.argv.length > 2) {
+        const args = process.argv.slice(2);
+        branch = args[0];
+    }
+
     const brandsWithTokens = await Promise.all(
         BRANDS.map((brand) => {
-            console.log(`Getting ${brand.misticaDesignFileName} tokens from mistica-design/${BRANCH}...`);
-            return downloadTokens(BRANCH, brand.misticaDesignFileName).then((tokens) => ({
+            console.log(`Getting ${brand.misticaDesignFileName} tokens from mistica-design/${branch}...`);
+            return downloadTokens(branch, brand.misticaDesignFileName).then((tokens) => ({
                 brand,
                 tokens,
             }));


### PR DESCRIPTION
## 🎟️ **Jira ticket**
https://jira.tid.es/browse/IOS-10974

## 🥅 **What's the goal?**
When `mistica-design` job trigger our `generate-mistica-tokens.yml`, it fails:
https://github.com/Telefonica/mistica-design/actions/runs/13055903096/job/36426747377#step:3:17

`ref` param is unexpected.

## 🚧 **How do we do it?**
Allow this (optional) param.

## 🧪 **How can I verify this?**
- Job: https://github.com/Telefonica/mistica-ios/actions/runs/13074654923/job/36483749212
- Output: https://github.com/Telefonica/mistica-ios/pull/424

