### PR TITLE
IOS-11139 Remove crouton queue to avoid enqueuing messages. From now …

### DIFF
--- a/Sources/Mistica/Components/Crouton/Presentation/CroutonController.swift
+++ b/Sources/Mistica/Components/Crouton/Presentation/CroutonController.swift
@@ -13,7 +13,7 @@ public class CroutonController: NSObject {
         public typealias Closure = () -> UIViewController?
         public static let `default`: Closure = { UIApplication.shared.windows.filter(\.isKeyWindow).first?.rootViewController }
     }
-    
+
     public typealias ActionConfig = (text: String, accessibilityLabel: String?, handler: DidTapActionBlock)
     public typealias DismissHandlerBlock = (SnackbarDismissReason) -> Void
     public typealias DidTapActionBlock = () -> Void
@@ -49,7 +49,7 @@ public extension CroutonController {
 
         let dismissHandler: (SnackbarDismissReason) -> Void = { dismissReason in
             self.dismissCurrentCrouton()
-            
+
             dismissHandler?(dismissReason)
         }
 
@@ -77,7 +77,7 @@ public extension CroutonController {
             exactViewController: exactViewController,
             rootViewController: rootViewController
         )
-        
+
         show(ongoingCrouton)
     }
 
@@ -99,9 +99,9 @@ private extension CroutonController {
         dismissCurrentCrouton()
         guard let view = crouton.view() else { return }
         crouton.croutonView.show(in: view)
-        self.currentCroutonView = crouton.croutonView
+        currentCroutonView = crouton.croutonView
     }
-    
+
     func dismissCurrentCrouton() {
         currentCroutonView?.dismiss()
         currentCroutonView = nil

--- a/Sources/Mistica/Components/Crouton/Presentation/CroutonController.swift
+++ b/Sources/Mistica/Components/Crouton/Presentation/CroutonController.swift
@@ -13,15 +13,12 @@ public class CroutonController: NSObject {
         public typealias Closure = () -> UIViewController?
         public static let `default`: Closure = { UIApplication.shared.windows.filter(\.isKeyWindow).first?.rootViewController }
     }
-
-    public typealias Token = UUID
+    
     public typealias ActionConfig = (text: String, accessibilityLabel: String?, handler: DidTapActionBlock)
-
     public typealias DismissHandlerBlock = (SnackbarDismissReason) -> Void
     public typealias DidTapActionBlock = () -> Void
 
-    private var croutonViewList = [OngoingCrouton]()
-    private var showingToken: Token?
+    private var currentCroutonView: CroutonView?
 
     public static let shared = CroutonController()
 
@@ -31,7 +28,7 @@ public class CroutonController: NSObject {
 // MARK: Public functions
 
 public extension CroutonController {
-    /// Show a crouton (or enqueue one if there is already a crouton shown)
+    /// Show a crouton
     /// - Parameters:
     ///   - text: The text to display in the crouton
     ///   - action: An optional action which will show a button with the given title and invoke the handler when the button is pressed
@@ -39,21 +36,20 @@ public extension CroutonController {
     ///   - dismissHandler: A handler which is called when the handler is removed from the screen
     ///   - exactViewController: The exacti viewCotroller where the croutono will be show. Has priority over rootViewController
     ///   - rootViewController: The root view controller that will show the crouton.
-    @discardableResult
     func showCrouton(
         config: SnackbarConfig,
         style: CroutonStyle = .info,
         dismissHandler: DismissHandlerBlock? = nil,
         exactViewController: UIViewController? = nil,
         rootViewController: RootViewController.Closure? = nil
-    ) -> Token {
+    ) {
         assertMainThread()
 
         let styleConfig = CroutonConfig(style: style, croutonDismissInterval: config.dismissInterval)
 
         let dismissHandler: (SnackbarDismissReason) -> Void = { dismissReason in
             self.dismissCurrentCrouton()
-
+            
             dismissHandler?(dismissReason)
         }
 
@@ -68,7 +64,6 @@ public extension CroutonController {
             )
         }
 
-        let token = Token()
         let croutonView = CroutonView(
             text: config.title,
             action: overwrittenAction,
@@ -78,38 +73,22 @@ public extension CroutonController {
         )
 
         let ongoingCrouton = OngoingCrouton(
-            token: token,
             croutonView: croutonView,
             exactViewController: exactViewController,
             rootViewController: rootViewController
         )
+        
         show(ongoingCrouton)
-
-        return token
     }
 
     var isShowingACrouton: Bool {
-        showingToken != nil
+        currentCroutonView != nil
     }
 
-    /// Dismisses (or removes from enqueued croutons) the crouton identified by `token`
-    /// - Parameter token: a unique token that identifies a crouton
-    func dismiss(token: Token) {
+    /// Dismisses the current crouton if it exists
+    func dismiss() {
         assertMainThread()
-
-        // There has to be a shown crouton (even if it's not the one we are interested in)
-        guard let showingToken = showingToken else { return }
-
-        if showingToken == token {
-            dismissCurrentCrouton()
-        } else if let index = croutonViewList.firstIndex(where: { token == $0.token }) {
-            croutonViewList.remove(at: index)
-        }
-    }
-
-    func dismissAll() {
-        assertMainThread()
-        dismissAllFromCurrentCrouton()
+        dismissCurrentCrouton()
     }
 }
 
@@ -117,48 +96,14 @@ public extension CroutonController {
 
 private extension CroutonController {
     func show(_ crouton: OngoingCrouton) {
-        enqueue(crouton)
-        showEnqueuedCrouton()
+        dismissCurrentCrouton()
+        guard let view = crouton.view() else { return }
+        crouton.croutonView.show(in: view)
+        self.currentCroutonView = crouton.croutonView
     }
-
+    
     func dismissCurrentCrouton() {
-        guard let crouton = dequeue() else { return }
-
-        crouton.croutonView.dismiss {
-            self.showingToken = nil
-            self.showEnqueuedCrouton()
-        }
-    }
-
-    func dismissAllFromCurrentCrouton() {
-        guard let ongoingCrouton = dequeue() else { return }
-
-        ongoingCrouton.croutonView.dismiss {
-            self.showingToken = nil
-
-            while let ongoingCrouton = self.dequeue() {
-                ongoingCrouton.croutonView.dismiss()
-            }
-        }
-    }
-
-    func enqueue(_ ongoingCrouton: OngoingCrouton) {
-        croutonViewList.append(ongoingCrouton)
-    }
-
-    func dequeue() -> OngoingCrouton? {
-        guard !croutonViewList.isEmpty else { return nil }
-
-        return croutonViewList.remove(at: 0)
-    }
-
-    func showEnqueuedCrouton() {
-        guard showingToken == nil else { return }
-        guard let ongoingCrouton = croutonViewList.first else { return }
-        guard let containerView = ongoingCrouton.view() else { return }
-
-        showingToken = ongoingCrouton.token
-
-        ongoingCrouton.croutonView.show(in: containerView)
+        currentCroutonView?.dismiss()
+        currentCroutonView = nil
     }
 }

--- a/Sources/Mistica/Components/Crouton/Presentation/OngoingCrouton.swift
+++ b/Sources/Mistica/Components/Crouton/Presentation/OngoingCrouton.swift
@@ -10,18 +10,15 @@ import UIKit
 
 extension CroutonController {
     struct OngoingCrouton {
-        let token: Token
         let croutonView: CroutonView
         private weak var exactViewController: UIViewController?
         private let rootViewController: RootViewController.Closure
 
         init(
-            token: Token,
             croutonView: CroutonView,
             exactViewController: UIViewController? = nil,
             rootViewController: RootViewController.Closure? = nil
         ) {
-            self.token = token
             self.croutonView = croutonView
             self.exactViewController = exactViewController
             self.rootViewController = rootViewController ?? RootViewController.default


### PR DESCRIPTION
## 🎟️ **Jira ticket**
[IOS-11139](https://jira.tid.es/browse/IOS-11139) Remove croutons queue behavior in UIKit
## 🥅 **What's the goal?**
Remove croutons queue from UIKit to avoid that a consecutive crouton is not shown until the previous one is closed.

## 🚧 **How do we do it?**
Remove the enque solution in CroutonController and dismiss the previous crouton if exists when a new one needs to be shown.

## 🧪 **How can I verify this?**
Open the Catalog and try to launch several UIKit croutons.


https://github.com/user-attachments/assets/a2955676-1c1d-4e32-8ae1-2f6b584cd7f6



## 🏑 **AppCenter build**

![qr](https://github.com/user-attachments/assets/ebb9b5b3-4f65-4f80-814d-5248d3bc442f)
