### PR TITLE
IOS-11147 Update node version as a dependency of the latest semantic-…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3.6.0
         with:
-          node-version: 18.13.0
+          node-version: 20.8.1
 
       - name: Release
         env:


### PR DESCRIPTION
## 🎟️ **Jira ticket**
[IOS-11147](https://jira.tid.es/browse/IOS-11147) Update node version in release workflow to support the latest update version of semantic release v24.2.3

## 🥅 **What's the goal?**
Update Node to v20.8.1 to support semantic release v24.2.3: https://github.com/Telefonica/mistica-ios/actions/runs/13905664345/job/38908013624

## 🚧 **How do we do it?**
Update release workflow and changed the Node version to v20.8.1

## 🧪 **How can I verify this?**
Launching the GA...

## 🏑 **AppCenter build**
