### PR TITLE
IOS-11147 Update releasrc and update_version script to be executed in…

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -4,7 +4,7 @@
         "@semantic-release/release-notes-generator",
         "@semantic-release/changelog",
         ["@semantic-release/exec", {
-            "prepareCmd": "./scripts/update-version.sh ${nextRelease.version}"
+            "prepareCmd": "bash ./scripts/update-version.sh ${nextRelease.version}"
         }],
         ["@semantic-release/git", {
             "assets": ["CHANGELOG.md", "Sources/SupportFiles/Mistica.xcconfig", "MisticaCatalog/SupportFiles/MisticaCatalogConfig.xcconfig"]

--- a/.releaserc
+++ b/.releaserc
@@ -4,7 +4,7 @@
         "@semantic-release/release-notes-generator",
         "@semantic-release/changelog",
         ["@semantic-release/exec", {
-            "prepareCmd": "bash ./scripts/update-version.sh ${nextRelease.version}"
+            "prepareCmd": "./scripts/update-version.sh ${nextRelease.version}"
         }],
         ["@semantic-release/git", {
             "assets": ["CHANGELOG.md", "Sources/SupportFiles/Mistica.xcconfig", "MisticaCatalog/SupportFiles/MisticaCatalogConfig.xcconfig"]

--- a/scripts/update-version.sh
+++ b/scripts/update-version.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # Script used to change the version number on Mistica
 if [[ ! $1 =~ (0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*))*))?(\+([0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*))? ]]; then
     echo "No valid version supplied"


### PR DESCRIPTION
## 🎟️ **Jira ticket**
[IOS-11147](https://jira.tid.es/browse/IOS-11147) Force to execute update_version script in a bash shell

## 🥅 **What's the goal?**
After updating semantic release to v24.2.3 and Node to v20.8.1 in the release GA workflow it's failing when executing the update_version script with a syntax error: https://github.com/Telefonica/mistica-ios/actions/runs/13906207275/job/38909727041

I have been looking for a solution and it seems that the default shell used by a GA is sh and the script is a bash shell. [[ ... ]] seems to not be fully supported by sh and is a Bash-specific syntax. The question is why was working with the previous semantic-release/exec versions...

## 🚧 **How do we do it?**
Update releasers config file and the update_version script to force to be executed in a bash shell.

## 🧪 **How can I verify this?**
Launching the GA( the dry-run mode does skip the exec prepare stuff...)
I've create a branch to run only the update version script with both shells, sh and bash. The results( note that the error is different in both cases):
| sh | bash |
|--------|-------|
|   ![Screenshot 2025-03-18 at 10 14 32](https://github.com/user-attachments/assets/543fb1ed-0b81-45d7-af7a-0b79bc1252fd)    |    ![Screenshot 2025-03-18 at 10 21 13](https://github.com/user-attachments/assets/def47374-f2b5-4d15-812c-273e1cd37bf4)   |

## 🏑 **AppCenter build**
