### PR TITLE
IOS-11147 Fix the update version script to be compatible with Ubuntu …

### DIFF
--- a/scripts/update-version.sh
+++ b/scripts/update-version.sh
@@ -8,8 +8,4 @@ fi
 VERSION_NUMBER=$1
 echo "Updating xcconfig and mistica catalog version number to $VERSION_NUMBER"
 
-# Execute from the root project folder
-cd Mistica &>/dev/null
-cd .. &>/dev/null
-
-find . -name "Mistica*.xcconfig" -exec sed -i '' -E "s/(VERSION_NUMBER = ).*/\1$VERSION_NUMBER/" {} +
+find . -name "Mistica*.xcconfig" -exec sed -i -E "s/(VERSION_NUMBER = ).*/\1$VERSION_NUMBER/" {} +


### PR DESCRIPTION
## 🎟️ **Jira ticket**
[IOS-11147](https://jira.tid.es/browse/IOS-11147) Fix update version script to be compatible with Ubuntu

## 🥅 **What's the goal?**
Make the script work again in Ubuntu.

## 🚧 **How do we do it?**
1. Change the sed command syntax to be compatible with the GNU sed version instead of BSD version( macOS ).
2. Removed 2 commands that navigate into a non existing Mistica folder and then to the root project again. As we use find to search the xcconfig files we don't need this.

## 🧪 **How can I verify this?**
Test where only the update script was executed
https://github.com/Telefonica/mistica-ios/actions/runs/13942075254/job/39020828997

## 🏑 **AppCenter build**
