### PR TITLE
IOS-10545 Fix Strict Concurrency in XCode 16.2

### DIFF
--- a/Sources/MisticaSwiftUI/Components/Carousel/Carousels/TrackableScrollView.swift
+++ b/Sources/MisticaSwiftUI/Components/Carousel/Carousels/TrackableScrollView.swift
@@ -34,7 +34,9 @@ public struct TrackableScrollView<Content>: View where Content: View {
                 content.background(offsetOverlay(outsideProxy: outsideProxy))
             }
             .onPreferenceChange(ScrollOffsetPreferenceKey.self) { value in
-                contentOffset = value[0]
+                Task { @MainActor in
+                    contentOffset = value[0]
+                }
             }
         }
     }

--- a/Sources/MisticaSwiftUI/Components/Carousel/Carousels/TrackableScrollView.swift
+++ b/Sources/MisticaSwiftUI/Components/Carousel/Carousels/TrackableScrollView.swift
@@ -34,7 +34,7 @@ public struct TrackableScrollView<Content>: View where Content: View {
                 content.background(offsetOverlay(outsideProxy: outsideProxy))
             }
             .onPreferenceChange(ScrollOffsetPreferenceKey.self) { value in
-                Task { @MainActor in
+                DispatchQueue.main.async {
                     contentOffset = value[0]
                 }
             }

--- a/Sources/MisticaSwiftUI/Components/Carousel/Carousels/TrackableScrollView.swift
+++ b/Sources/MisticaSwiftUI/Components/Carousel/Carousels/TrackableScrollView.swift
@@ -33,10 +33,8 @@ public struct TrackableScrollView<Content>: View where Content: View {
             ScrollView(axes, showsIndicators: showsIndicators) {
                 content.background(offsetOverlay(outsideProxy: outsideProxy))
             }
-            .onPreferenceChange(ScrollOffsetPreferenceKey.self) { value in
-                DispatchQueue.main.async {
-                    contentOffset = value[0]
-                }
+            .onPreferenceChange(ScrollOffsetPreferenceKey.self) { [$contentOffset] value in
+                $contentOffset.wrappedValue = value[0]
             }
         }
     }

--- a/Sources/MisticaSwiftUI/Components/Tabs/Tabs.swift
+++ b/Sources/MisticaSwiftUI/Components/Tabs/Tabs.swift
@@ -68,7 +68,7 @@ public struct Tabs: View {
                     )
                     // Store the new value whenever it changes.
                     .onPreferenceChange(CGFloatPreferenceKey.self) { width in
-                        Task { @MainActor in
+                        DispatchQueue.main.async {
                             self.itemWidth[index] = min(width, 208)
                         }
                     }

--- a/Sources/MisticaSwiftUI/Components/Tabs/Tabs.swift
+++ b/Sources/MisticaSwiftUI/Components/Tabs/Tabs.swift
@@ -67,10 +67,8 @@ public struct Tabs: View {
                         }
                     )
                     // Store the new value whenever it changes.
-                    .onPreferenceChange(CGFloatPreferenceKey.self) { width in
-                        DispatchQueue.main.async {
-                            self.itemWidth[index] = min(width, 208)
-                        }
+                    .onPreferenceChange(CGFloatPreferenceKey.self) { [$itemWidth] width in
+                        $itemWidth[index].wrappedValue = min(width, 208)
                     }
                     .onTapGesture {
                         self.selection = index

--- a/Sources/MisticaSwiftUI/Components/Tabs/Tabs.swift
+++ b/Sources/MisticaSwiftUI/Components/Tabs/Tabs.swift
@@ -68,7 +68,9 @@ public struct Tabs: View {
                     )
                     // Store the new value whenever it changes.
                     .onPreferenceChange(CGFloatPreferenceKey.self) { width in
-                        self.itemWidth[index] = min(width, 208)
+                        Task { @MainActor in
+                            self.itemWidth[index] = min(width, 208)
+                        }
                     }
                     .onTapGesture {
                         self.selection = index

--- a/Sources/MisticaSwiftUI/Utils/Modifiers/SizeViewModifier.swift
+++ b/Sources/MisticaSwiftUI/Utils/Modifiers/SizeViewModifier.swift
@@ -30,16 +30,16 @@ struct SizeModifier: ViewModifier {
 }
 
 public extension View {
-    func onSizeChange(_ callback: @escaping (CGSize) -> Void) -> some View {
+    func onSizeChange(_ callback: @Sendable @escaping (CGSize) -> Void) -> some View {
         modifier(SizeModifier())
             .onPreferenceChange(SizePreferenceKey.self, perform: callback)
     }
 
-    func onWidthChange(_ callback: @escaping (CGFloat) -> Void) -> some View {
+    func onWidthChange(_ callback: @Sendable @escaping (CGFloat) -> Void) -> some View {
         onSizeChange { callback($0.width) }
     }
 
-    func onHeightChange(_ callback: @escaping (CGFloat) -> Void) -> some View {
+    func onHeightChange(_ callback: @Sendable @escaping (CGFloat) -> Void) -> some View {
         onSizeChange { callback($0.height) }
     }
 }


### PR DESCRIPTION
## 🎟️ **Jira ticket**
https://jira.tid.es/browse/IOS-10545

## 🥅 **What's the goal?**
Concurrency bugs have been detected that only appear in XCode version 16.2. 

The fact that they do not appear in the other versions of XCode does not mean that it is a concurrency error that must be fixed.

## 🚧 **How do we do it?**
The closure of the `onPreferenceChange` method is `Sendable` and therefore if we want to access an isolated value in `MainActor` we must guarantee that the context where it is accessed is also `MainActor`.

However, `onPreferenceChange` method is not isolated in `MainActor` so it is necessary to isolate its closure in a `Task` that is.

## 🧪 **How can I verify this?**
You should not see any compile errors in XCode 16.2.

