### PR TITLE
IOS-11150 update lottie sdk to 4.5.1

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "fabf412b37876aec162d7a166eeac275950a28ec25bf2a551982d1be8d88c5c5",
+  "originHash" : "afc2dc069e206133d7267445d63fd15d07a67e678ffd12bc8558a9e2e42b5dfa",
   "pins" : [
     {
       "identity" : "lottie-spm",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/airbnb/lottie-spm.git",
       "state" : {
-        "revision" : "b842598f1295f3ffa1475b1580672d1fe5b83580",
-        "version" : "4.5.0"
+        "revision" : "8c6edf4f0fa84fe9c058600a4295eb0c01661c69",
+        "version" : "4.5.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/airbnb/lottie-spm.git", exact: "4.5.0"),
+        .package(url: "https://github.com/airbnb/lottie-spm.git", exact: "4.5.1"),
         .package(url: "https://github.com/pointfreeco/swift-snapshot-testing.git", exact: "1.17.6"),
         .package(url: "https://github.com/SDWebImage/SDWebImage.git", exact: "5.19.1"),
         .package(url: "https://github.com/SDWebImage/SDWebImageSVGCoder.git", exact: "1.7.0")


### PR DESCRIPTION
<!-- This warning is to remind you to check if a designer needs to review this PR. Delete it when you consider it -->
> [!WARNING]
> Should a designer need to review/verify this PR?

## 🎟️ **Jira ticket**
https://jira.tid.es/browse/IOS-11150

## 🥅 **What's the goal?**
Update lottie sdk to latest 4.5.1. 
https://github.com/airbnb/lottie-spm/tags

Note: 
To avoid dependency conflicts and ensure compatibility, apps that integrate Mistica and Lottie should update to the same version of Lottie.

## 🚧 **How do we do it?**
Update sdk; no changes needed


## 🧪 **How can I verify this?**
Tested proper behaviour.

https://github.com/user-attachments/assets/5ad73e2a-7946-4fb5-a892-7fdbac3bab82



## 🏑 **AppCenter build**
