### PR TITLE
Add flow token to notify

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,3 +39,5 @@ jobs:
         uses: ./.github/actions/microsoft-teams/notify
         with:
           channel: ios_releases
+          flow-token: ${{ secrets.NOVUM_FLOW_BEARER }}
+


### PR DESCRIPTION
In order to notify to teams in public runners using the internal action we need the private novum token

This is to fix release executions like: 
https://github.com/Telefonica/mistica-ios/actions/runs/15303623918/job/43050533903#step:6:34