### PR TITLE
Ios 11095 automatic focus snackbar critical cases

### DIFF
--- a/MisticaCatalog/Source/Catalog/Mistica/Components/UICatalogSnackbarViewController.swift
+++ b/MisticaCatalog/Source/Catalog/Mistica/Components/UICatalogSnackbarViewController.swift
@@ -166,10 +166,10 @@ private extension UICatalogSnackbarViewController {
 
         case .infinite:
             guard let action = actionTitleCell.textField.text, !action.isEmpty else {
-                return .infinite(nil)
+                return .infinite(nil, autoFocus: false)
             }
 
-            return .infinite(SnackbarAction(title: action, handler: {}))
+            return .infinite(SnackbarAction(title: action, handler: {}), autoFocus: true)
         case .none:
             return .fiveSeconds
         }

--- a/Sources/Mistica/Components/Snackbar/Presentation/SnackbarView.swift
+++ b/Sources/Mistica/Components/Snackbar/Presentation/SnackbarView.swift
@@ -211,7 +211,7 @@ extension SnackbarView {
                 container.layoutIfNeeded()
             },
             completion: { _ in
-                AccessibilityHelper.post(self.text)
+                self.triggerAccessibilityAction()
 
                 container.clipsToBounds = previousClipsToBounds
 
@@ -267,6 +267,13 @@ extension SnackbarView {
 private extension SnackbarView {
     var shouldShowCloseButton: Bool {
         forceDismiss || (action == nil && config.overrideDismissInterval == .infinite(nil))
+    }
+    func triggerAccessibilityAction() {
+        if config.overrideDismissInterval.shouldAutoFocus {
+            UIAccessibility.post(notification: .layoutChanged, argument: self)
+        } else {
+            AccessibilityHelper.post(self.text)
+        }
     }
 
     func layoutViews() {

--- a/Sources/Mistica/Components/Snackbar/Presentation/SnackbarView.swift
+++ b/Sources/Mistica/Components/Snackbar/Presentation/SnackbarView.swift
@@ -183,6 +183,12 @@ class SnackbarView: UIView {
 
 extension SnackbarView {
     func show(in container: UIView) {
+    
+        guard Thread.isMainThread else {
+            DispatchQueue.main.async { self.show(in: container) }
+            return
+        }
+
         let previousClipsToBounds = container.clipsToBounds
         container.clipsToBounds = true
 
@@ -211,6 +217,7 @@ extension SnackbarView {
                 container.layoutIfNeeded()
             },
             completion: { _ in
+              
                 self.triggerAccessibilityAction()
 
                 container.clipsToBounds = previousClipsToBounds
@@ -265,9 +272,11 @@ extension SnackbarView {
 // MARK: Private methods
 
 private extension SnackbarView {
+
     var shouldShowCloseButton: Bool {
         forceDismiss || (action == nil && config.overrideDismissInterval == .infinite(nil))
     }
+
     func triggerAccessibilityAction() {
         if config.overrideDismissInterval.shouldAutoFocus {
             UIAccessibility.post(notification: .layoutChanged, argument: self)

--- a/Sources/Mistica/Components/Snackbar/Presentation/SnackbarView.swift
+++ b/Sources/Mistica/Components/Snackbar/Presentation/SnackbarView.swift
@@ -183,7 +183,6 @@ class SnackbarView: UIView {
 
 extension SnackbarView {
     func show(in container: UIView) {
-
         let previousClipsToBounds = container.clipsToBounds
         container.clipsToBounds = true
 
@@ -212,7 +211,7 @@ extension SnackbarView {
                 container.layoutIfNeeded()
             },
             completion: { _ in
-              
+
                 self.triggerAccessibilityAction()
 
                 container.clipsToBounds = previousClipsToBounds
@@ -267,21 +266,19 @@ extension SnackbarView {
 // MARK: Private methods
 
 private extension SnackbarView {
-
     var shouldShowCloseButton: Bool {
         forceDismiss || (action == nil && config.overrideDismissInterval == .infinite(nil))
     }
 
     func triggerAccessibilityAction() {
-        
         if config.overrideDismissInterval.autoFocus {
             let delay = config.overrideDismissInterval.autoFocusDelay ?? 0.0
             DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
                 UIAccessibility.post(notification: .layoutChanged, argument: self)
             }
-            
+
         } else {
-            AccessibilityHelper.post(self.text)
+            AccessibilityHelper.post(text)
         }
     }
 

--- a/Sources/Mistica/Components/Snackbar/Presentation/SnackbarView.swift
+++ b/Sources/Mistica/Components/Snackbar/Presentation/SnackbarView.swift
@@ -183,11 +183,6 @@ class SnackbarView: UIView {
 
 extension SnackbarView {
     func show(in container: UIView) {
-    
-        guard Thread.isMainThread else {
-            DispatchQueue.main.async { self.show(in: container) }
-            return
-        }
 
         let previousClipsToBounds = container.clipsToBounds
         container.clipsToBounds = true
@@ -278,8 +273,13 @@ private extension SnackbarView {
     }
 
     func triggerAccessibilityAction() {
-        if config.overrideDismissInterval.shouldAutoFocus {
-            UIAccessibility.post(notification: .layoutChanged, argument: self)
+        
+        if config.overrideDismissInterval.autoFocus {
+            let delay = config.overrideDismissInterval.autoFocusDelay ?? 0.0
+            DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
+                UIAccessibility.post(notification: .layoutChanged, argument: self)
+            }
+            
         } else {
             AccessibilityHelper.post(self.text)
         }

--- a/Sources/MisticaCommon/Components/Snackbar/Domain/SnackbarConfig.swift
+++ b/Sources/MisticaCommon/Components/Snackbar/Domain/SnackbarConfig.swift
@@ -55,7 +55,7 @@ public enum SnackbarDismissInterval: Equatable {
             return true
         }
     }
-    
+
     public var autoFocus: Bool {
         switch self {
         case .infinite(_, let autoFocus, _):
@@ -73,8 +73,6 @@ public enum SnackbarDismissInterval: Equatable {
             return nil
         }
     }
-
-
 
     public static func == (lhs: SnackbarDismissInterval, rhs: SnackbarDismissInterval) -> Bool {
         switch (lhs, rhs) {

--- a/Sources/MisticaCommon/Components/Snackbar/Domain/SnackbarConfig.swift
+++ b/Sources/MisticaCommon/Components/Snackbar/Domain/SnackbarConfig.swift
@@ -23,7 +23,7 @@ public struct SnackbarAction {
 public enum SnackbarDismissInterval: Equatable {
     case fiveSeconds
     case tenSeconds(SnackbarAction)
-    case infinite(SnackbarAction?, autoFocus: Bool = false)
+    case infinite(SnackbarAction?, autoFocus: Bool = false, autoFocusDelay: TimeInterval? = nil)
 
     public var timeInterval: TimeInterval? {
         switch self {
@@ -42,7 +42,7 @@ public enum SnackbarDismissInterval: Equatable {
             return nil
         case .tenSeconds(let action):
             return action
-        case .infinite(let action, _):
+        case .infinite(let action, _, _):
             return action
         }
     }
@@ -56,14 +56,24 @@ public enum SnackbarDismissInterval: Equatable {
         }
     }
     
-    public var shouldAutoFocus: Bool {
+    public var autoFocus: Bool {
         switch self {
-        case .infinite(_, let autoFocus):
+        case .infinite(_, let autoFocus, _):
             return autoFocus
         case .fiveSeconds, .tenSeconds:
             return false
         }
     }
+
+    public var autoFocusDelay: TimeInterval? {
+        switch self {
+        case .infinite(_, _, let delay):
+            return delay
+        case .fiveSeconds, .tenSeconds:
+            return nil
+        }
+    }
+
 
 
     public static func == (lhs: SnackbarDismissInterval, rhs: SnackbarDismissInterval) -> Bool {
@@ -72,7 +82,7 @@ public enum SnackbarDismissInterval: Equatable {
             return true
         case (.tenSeconds(_), .tenSeconds(_)):
             return true
-        case (.infinite(_, _), .infinite(_, _)):
+        case (.infinite(_, _, _), .infinite(_, _, _)):
             return true
         default:
             return false

--- a/Sources/MisticaCommon/Components/Snackbar/Domain/SnackbarConfig.swift
+++ b/Sources/MisticaCommon/Components/Snackbar/Domain/SnackbarConfig.swift
@@ -23,7 +23,7 @@ public struct SnackbarAction {
 public enum SnackbarDismissInterval: Equatable {
     case fiveSeconds
     case tenSeconds(SnackbarAction)
-    case infinite(SnackbarAction?)
+    case infinite(SnackbarAction?, autoFocus: Bool = false)
 
     public var timeInterval: TimeInterval? {
         switch self {
@@ -42,7 +42,7 @@ public enum SnackbarDismissInterval: Equatable {
             return nil
         case .tenSeconds(let action):
             return action
-        case .infinite(let action):
+        case .infinite(let action, _):
             return action
         }
     }
@@ -55,6 +55,16 @@ public enum SnackbarDismissInterval: Equatable {
             return true
         }
     }
+    
+    public var shouldAutoFocus: Bool {
+        switch self {
+        case .infinite(_, let autoFocus):
+            return autoFocus
+        case .fiveSeconds, .tenSeconds:
+            return false
+        }
+    }
+
 
     public static func == (lhs: SnackbarDismissInterval, rhs: SnackbarDismissInterval) -> Bool {
         switch (lhs, rhs) {
@@ -62,7 +72,7 @@ public enum SnackbarDismissInterval: Equatable {
             return true
         case (.tenSeconds(_), .tenSeconds(_)):
             return true
-        case (.infinite(_), .infinite(_)):
+        case (.infinite(_, _), .infinite(_, _)):
             return true
         default:
             return false


### PR DESCRIPTION
<!-- This warning is to remind you to check if a designer needs to review this PR. Delete it when you consider it -->
> [!WARNING]
> Should a designer need to review/verify this PR?

## 🎟️ **Jira ticket**
https://jira.tid.es/browse/IOS-11095

## 🥅 **What's the goal?**
The Snackbar specifications have been updated for accessibility. For critical persistent Snackbars, the focus will now automatically move to ensure better accessibility.

## 🚧 **How do we do it?**

A new parameter has been added to move the focus to persistent Snackbars. Additionally, a delay parameter has been introduced to ensure the focus movement, for cases when UI changes are still rendering or have animations.

## 🧪 **How can I verify this?**

https://github.com/user-attachments/assets/25bf7ad5-edc8-43d3-8c8d-ec97ca598022



## 🏑 **AppCenter build**
