### PR TITLE
FIX - Fix voiceOver spoken first element in Feedback view - refs IOS-11534

### DIFF
--- a/Sources/Mistica/Components/Feedback/FeedbackView.swift
+++ b/Sources/Mistica/Components/Feedback/FeedbackView.swift
@@ -386,7 +386,9 @@ private extension FeedbackView {
         }
 
         // Prepare
-        views.forEach(prepare(view:))
+        for view in views {
+            prepare(view: view)
+        }
 
         // Generate animators
         animators = views.map(animation).map { animation in

--- a/Sources/Mistica/Components/Feedback/FeedbackView.swift
+++ b/Sources/Mistica/Components/Feedback/FeedbackView.swift
@@ -365,7 +365,7 @@ private extension FeedbackView {
         }
 
         guard UIView.areAnimationsEnabled, style.shouldAnimate else {
-            self.enableButtonsAccessibility()
+            enableButtonsAccessibility()
             return
         }
         animationFired = false
@@ -387,7 +387,7 @@ private extension FeedbackView {
 
         // Prepare
         views.forEach(prepare(view:))
-        
+
         // Generate animators
         animators = views.map(animation).map { animation in
             let animator = animator
@@ -425,7 +425,7 @@ private extension FeedbackView {
             self?.animate(remaining: animators)
         }
     }
-    
+
     func enableButtonsAccessibility() {
         primaryButton?.isAccessibilityElement = true
         secondaryButton?.isAccessibilityElement = true


### PR DESCRIPTION
Set primary and secondary buttons as non-accessibility elements during setup, then re-enable accessibility after animations complete. This ensures accessibility elements are only active when appropriate, improving user experience for assistive technologies.

## 🎟️ **Jira ticket**
[IOS-11534](https://jira.tid.es/browse/IOS-11534)

## 🥅 **What's the goal?**
- Fix the first element spoken by VoiceOver when opening FeedbackViewController modally

## 🚧 **How do we do it?**
- Temporarily disable button's accessibility until the title/subtitle views are visible 

## 🧪 **How can I verify this?**

https://github.com/user-attachments/assets/a2132596-971b-401d-a3e3-c35f58cccbdc
