### PR TITLE
IOS-11606 Fix snackbar constraint when dismiss

### DIFF
--- a/Sources/Mistica/Components/Snackbar/Presentation/SnackbarView.swift
+++ b/Sources/Mistica/Components/Snackbar/Presentation/SnackbarView.swift
@@ -235,9 +235,6 @@ extension SnackbarView {
         let previousClipsToBounds = superview.clipsToBounds
         superview.clipsToBounds = true
 
-        let snackbarHeight = frame.height
-        let temporaryHeightConstraint = heightAnchor.constraint(equalToConstant: snackbarHeight)
-        temporaryHeightConstraint.isActive = true
         let dismissalOffset = calculateDismissalOffset(in: superview)
 
         UIView.animate(
@@ -251,14 +248,11 @@ extension SnackbarView {
             },
             completion: { _ in
                 superview.clipsToBounds = previousClipsToBounds
-
                 self.removeFromSuperview()
-
-                temporaryHeightConstraint.isActive = false
-
                 completion?()
             }
         )
+
         fadeStackViewOut()
     }
 }


### PR DESCRIPTION
## 🎟️ **Jira ticket**
https://jira.tid.es/browse/IOS-11606

## 🥅 **What's the goal?**
Constraint errors occur when displaying and closing a Mistica snackbar from other projects.

## 🚧 **How do we do it?**
This PR fixes an Auto Layout conflict that occurred when dismissing a SnackbarView. The issue was caused by a hardcoded height constraint (heightAnchor.constraint(equalToConstant:)) being added during the dismissal animation, which conflicted with existing constraints tied to the view’s layout margins and internal stack views.

✅ Changes made:
- Removed the forced heightAnchor constraint during snackbar dismissal.
- Dismissal is now handled purely by updating the bottomConstraint and animating the opacity (alpha).
- Preserved existing layout logic and animation behavior (layoutIfNeeded and fadeStackViewOut()).

## 🧪 **How can I verify this?**
No constraints errors are triggered when snackbar is dismissed.

