### PR TITLE
EDIT - Make Callout's close image a button and accessible - IOS-11847

### DIFF
--- a/Sources/Mistica/Components/Callout/Callout.swift
+++ b/Sources/Mistica/Components/Callout/Callout.swift
@@ -20,7 +20,7 @@ private enum Constants {
 public class Callout: UIView {
     private lazy var calloutAccessibilityElement = UIAccessibilityElement(accessibilityContainer: self)
     private lazy var calloutContentBase = CalloutContentBase()
-    
+
     private lazy var closeButton: UIButton = {
         let button = UIButton(type: .custom)
         button.translatesAutoresizingMaskIntoConstraints = false
@@ -173,7 +173,7 @@ private extension Callout {
         insetsLayoutMarginsFromSafeArea = false
 
         addSubview(constrainedToLayoutMarginsGuideOf: calloutContentBase)
-        
+
         addSubview(closeButton, constraints: [
             closeButton.topAnchor.constraint(equalTo: topAnchor, constant: Constants.closeButtonTopMargin),
             closeButton.trailingAnchor.constraint(equalTo: trailingAnchor, constant: Constants.closeButtonTrailingMargin),
@@ -186,7 +186,7 @@ private extension Callout {
         calloutContentBase.configure(withConfiguration: configuration)
 
         closeButton.isHidden = !configuration.canClose
-        
+
         if configuration.inverse {
             backgroundColor = .backgroundContainer
         } else {
@@ -198,7 +198,7 @@ private extension Callout {
             configuration.description
         ].compactMap { $0 }.joined(separator: " ")
     }
-    
+
     @objc func closeButtonTapped() {
         onCloseButtonAction?()
         dismiss(animated: animated)


### PR DESCRIPTION
## 🎟️ **Jira ticket**
[IOS-11847](https://jira.tid.es/browse/IOS-11847)

## 🥅 **What's the goal?**
- Make sure the callout close view is accessible

## 🚧 **How do we do it?**
- Converting the image view to a UIButton

## 🧪 **How can I verify this?**

<img width="600" alt="Screenshot 2025-09-29 at 14 14 25" src="https://github.com/user-attachments/assets/7bdfa19b-3e8f-40bf-b36a-cacf79be69b3" />
